### PR TITLE
fix: support to other privilege elevation programs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +762,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uzers",
+ "which",
 ]
 
 [[package]]
@@ -1603,6 +1613,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.32",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1813,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ tracing-subscriber = { version = "0.3.18", features = [
     "std"
 ] }
 uzers = { version = "0.11.3", default-features = false }
+which = "6.0.1"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -47,6 +47,10 @@ pub struct NHParser {
     /// Show debug logs
     pub verbose: bool,
 
+    #[arg(short, long, global = true, value_hint = clap::ValueHint::ExecutablePath)]
+    /// Choose what privilege elevation program should be used
+    pub elevation_program: Option<OsString>,
+
     #[command(subcommand)]
     pub command: NHCommand,
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -47,7 +47,7 @@ pub struct NHParser {
     /// Show debug logs
     pub verbose: bool,
 
-    #[arg(short, long, global = true, value_hint = clap::ValueHint::ExecutablePath)]
+    #[arg(short, long, global = true, env, value_hint = clap::ValueHint::ExecutablePath)]
     /// Choose what privilege elevation program should be used
     pub elevation_program: Option<OsString>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod util;
 
 use crate::interface::NHParser;
 use crate::interface::NHRunnable;
+use crate::util::get_elevation_program;
 use color_eyre::Result;
 use tracing::debug;
 
@@ -26,7 +27,7 @@ fn main() -> Result<()> {
 fn self_elevate() -> ! {
     use std::os::unix::process::CommandExt;
 
-    let mut cmd = std::process::Command::new("sudo");
+    let mut cmd = std::process::Command::new(get_elevation_program().unwrap());
     cmd.args(std::env::args());
     debug!("{:?}", cmd);
     let err = cmd.exec();

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -133,7 +133,8 @@ impl OsRebuildArgs {
             let switch_to_configuration = switch_to_configuration.to_str().unwrap();
 
             commands::CommandBuilder::default()
-                .args(["sudo", switch_to_configuration, "test"])
+                .root(true)
+                .args([switch_to_configuration, "test"])
                 .message("Activating configuration")
                 .build()?
                 .exec()?;
@@ -141,8 +142,8 @@ impl OsRebuildArgs {
 
         if let Boot(_) | Switch(_) = rebuild_type {
             commands::CommandBuilder::default()
+                .root(true)
                 .args([
-                    "sudo",
                     "nix-env",
                     "--profile",
                     SYSTEM_PROFILE,
@@ -157,7 +158,8 @@ impl OsRebuildArgs {
             let switch_to_configuration = switch_to_configuration.to_str().unwrap();
 
             commands::CommandBuilder::default()
-                .args(["sudo", switch_to_configuration, "boot"])
+                .root(true)
+                .args([switch_to_configuration, "boot"])
                 .message("Adding configuration to bootloader")
                 .build()?
                 .exec()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,6 @@ use tracing::debug;
 use which::which;
 
 use std::ffi::OsString;
-use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 
@@ -79,6 +78,7 @@ pub fn get_nix_version() -> Result<String> {
 ///
 /// 1. `doas`
 /// 1. `sudo`
+/// 1. `run0`
 /// 1. `pkexec`
 ///
 /// The logic for choosing this order is that a person with doas installed is more likely
@@ -91,11 +91,14 @@ pub fn get_nix_version() -> Result<String> {
 pub fn get_elevation_program() -> Result<OsString> {
     let args = <NHParser as clap::Parser>::parse();
     if let Some(path) = args.elevation_program.map(|path| which(path)) {
-        debug!(?path, "privilege elevation path specified via command line argument");
+        debug!(
+            ?path,
+            "privilege elevation path specified via command line argument"
+        );
         return Ok(path?.into_os_string());
     }
 
-    const STRATEGIES: [&str; 3] = ["doas", "sudo", "pkexec"];
+    const STRATEGIES: [&str; 4] = ["doas", "sudo", "run0", "pkexec"];
 
     for strategy in STRATEGIES {
         if let Ok(path) = which(strategy) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -80,20 +80,13 @@ pub fn get_nix_version() -> Result<String> {
 /// * `Result<OsString>` - The absolute path to the privilege elevation program binary or an error if a
 /// program can't be found.
 pub fn get_elevation_program() -> Result<OsString> {
-    let has_doas = which("doas");
-    if let Ok(path) = has_doas {
-        debug!(?path, "doas path found");
-        return Ok(path.into_os_string());
-    }
-    let has_sudo = which("sudo");
-    if let Ok(path) = has_sudo {
-        debug!(?path, "sudo path found");
-        return Ok(path.into_os_string());
-    }
-    let has_pkexec = which("pkexec");
-    if let Ok(path) = has_pkexec {
-        debug!(?path, "pkexec path found");
-        return Ok(path.into_os_string());
+    let strategies = ["doas", "sudo", "pkexec"];
+
+    for strategy in strategies {
+        if let Ok(path) = which(strategy) {
+            debug!(?path, "{strategy} path found");
+            return Ok(path.into_os_string());
+        }
     }
 
     Err(eyre::eyre!("No elevation strategy found"))


### PR DESCRIPTION
This pr adds support for both `doas` and `pkexec`, while keeping support for `sudo`.

For this to work, I decided that the cleanest way to implement this was by adding a extra parameter to the Command struct that specifies if the command should be ran as root or not. When the root parameter is set, it checks for the existence of `doas`, `sudo`, and `pkexec`, in that order, and uses it to run the command by prefixing the command invocation arguments with the respective program when it is constructed.

The specified order was chosen because I believe that if someone has `doas` installed in their system, it's more likely that they use it as their main privilege escalation program. ´pkexec´ was added more as a fallback in case someone doesn't have `doas` or `sudo`.

This was tested in my NixOS Unstable system with both `sudo` and `doas`, but I haven't tested `pkexec` personally.