### PR TITLE
darwin.rs: handle new root only activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- Darwin: Future-proof handling of `activate-user` script removal
 - Darwin: Improve compatibility with root-only activation in newer nix-darwin versions
 
 ## 4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   support legacy/vulnerable versions of Nix, and encourage users to update if
   they have not yet done so.
 
+### Changed
+
+- Darwin: Improve compatibility with root-only activation in newer nix-darwin versions
+
 ## 4.0.3
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- Darwin: Use `darwin-rebuild` directly for activation instead of old scripts
 - Darwin: Future-proof handling of `activate-user` script removal
 - Darwin: Improve compatibility with root-only activation in newer nix-darwin versions
 

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -126,36 +126,27 @@ impl DarwinRebuildArgs {
                 .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
                 .arg(out_path.get_path())
                 .elevate(true)
-                .dry(self.common.dry);
+                .dry(self.common.dry)
+                .run()?;
 
+            let darwin_rebuild = out_path.get_path().join("sw/bin/darwin-rebuild");
             let activate_user = out_path.get_path().join("activate-user");
 
-            let user_activation = Command::new(activate_user.clone())
-                .message("Activating configuration for user")
-                .dry(self.common.dry);
-
-            let activate = out_path.get_path().join("activate");
-
-            let activation = Command::new(activate)
-                .elevate(true)
-                .message("Activating configuration")
-                .dry(self.common.dry);
-
-            if activate_user.exists() {
-                // Check whether activate-user is deprecated
-                // If it is, only activate with root
-                if std::fs::read_to_string(&activate_user)
+            // Determine if we need to elevate privileges
+            let needs_elevation = !activate_user
+                .try_exists()
+                .context("Failed to check if activate-user file exists")?
+                || std::fs::read_to_string(&activate_user)
                     .context("Failed to read activate-user file")?
-                    .contains("# nix-darwin: deprecated")
-                {
-                    activation.run()?;
-                } else {
-                    user_activation.run()?;
-                    activation.run()?;
-                }
-            } else {
-                activation.run()?;
-            }
+                    .contains("# nix-darwin: deprecated");
+
+            // Create and run the activation command with or without elevation
+            Command::new(darwin_rebuild)
+                .arg("activate")
+                .message("Activating configuration")
+                .elevate(needs_elevation)
+                .dry(self.common.dry)
+                .run()?;
         }
 
         // Make sure out_path is not accidentally dropped

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -141,15 +141,19 @@ impl DarwinRebuildArgs {
                 .message("Activating configuration")
                 .dry(self.common.dry);
 
-            // Check whether to activate-user is deprecated
-            // If it is, only activate with root
-            if std::fs::read_to_string(&activate_user)
-                .context("Failed to read activate-user file")?
-                .contains("# nix-darwin: deprecated")
-            {
-                activation.run()?;
+            if activate_user.exists() {
+                // Check whether activate-user is deprecated
+                // If it is, only activate with root
+                if std::fs::read_to_string(&activate_user)
+                    .context("Failed to read activate-user file")?
+                    .contains("# nix-darwin: deprecated")
+                {
+                    activation.run()?;
+                } else {
+                    user_activation.run()?;
+                    activation.run()?;
+                }
             } else {
-                user_activation.run()?;
                 activation.run()?;
             }
         }

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -126,23 +126,32 @@ impl DarwinRebuildArgs {
                 .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
                 .arg(out_path.get_path())
                 .elevate(true)
-                .dry(self.common.dry)
-                .run()?;
+                .dry(self.common.dry);
 
-            let switch_to_configuration = out_path.get_path().join("activate-user");
+            let activate_user = out_path.get_path().join("activate-user");
 
-            Command::new(switch_to_configuration)
+            let user_activation = Command::new(activate_user.clone())
                 .message("Activating configuration for user")
-                .dry(self.common.dry)
-                .run()?;
+                .dry(self.common.dry);
 
-            let switch_to_configuration = out_path.get_path().join("activate");
+            let activate = out_path.get_path().join("activate");
 
-            Command::new(switch_to_configuration)
+            let activation = Command::new(activate)
                 .elevate(true)
                 .message("Activating configuration")
-                .dry(self.common.dry)
-                .run()?;
+                .dry(self.common.dry);
+
+            // Check whether to activate-user is deprecated
+            // If it is, only activate with root
+            if std::fs::read_to_string(&activate_user)
+                .context("Failed to read activate-user file")?
+                .contains("# nix-darwin: deprecated")
+            {
+                activation.run()?;
+            } else {
+                user_activation.run()?;
+                activation.run()?;
+            }
         }
 
         // Make sure out_path is not accidentally dropped


### PR DESCRIPTION
Closes https://github.com/viperML/nh/issues/233

Basically, with the new nix-darwin rewrite everything is moved to root activation. I check if the nix-darwin user activation script contains the deprecation notice. ~If it does, we just call the activate script only. (Where the old user activation stuff has been moved)~ Also, moved to using the `darwin-rebuild` script instead of the activation scripts directly so that `nix-darwin` can handle migrations themselves and we don't have to worry about the current implementation details every time a change is made upstream. We just elevate the `activate` when it needs to be. 

Marking draft until the deprecation marker is solidified in https://github.com/LnL7/nix-darwin/pull/1341