### PR TITLE
make nh commands aware of NH_*_FLAKE

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -68,7 +68,7 @@ impl DarwinRebuildArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {
@@ -163,7 +163,7 @@ impl DarwinReplArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use color_eyre::eyre::{bail, Context};
 use tracing::{debug, info, warn};
 
@@ -59,10 +61,20 @@ impl DarwinRebuildArgs {
         debug!(?out_path);
 
         let mut installable = self.common.installable.clone();
+
         if let Installable::Flake {
-            ref mut attribute, ..
+            ref reference,
+            ref mut attribute,
+            ..
         } = installable
         {
+            // Check if using NH_DARWIN_FLAKE
+            if let Ok(darwin_flake) = env::var("NH_DARWIN_FLAKE") {
+                if darwin_flake == *reference {
+                    debug!("Using NH_DARWIN_FLAKE: {}", reference);
+                }
+            }
+
             // If user explicitly selects some other attribute, don't push darwinConfigurations
             if attribute.is_empty() {
                 attribute.push(String::from("darwinConfigurations"));
@@ -143,9 +155,18 @@ impl DarwinReplArgs {
         let hostname = self.hostname.ok_or(()).or_else(|()| get_hostname())?;
 
         if let Installable::Flake {
-            ref mut attribute, ..
+            ref reference,
+            ref mut attribute,
+            ..
         } = target_installable
         {
+            // Check if using NH_DARWIN_FLAKE
+            if let Ok(darwin_flake) = env::var("NH_DARWIN_FLAKE") {
+                if darwin_flake == *reference {
+                    debug!("Using NH_DARWIN_FLAKE: {}", reference);
+                }
+            }
+
             if attribute.is_empty() {
                 attribute.push(String::from("darwinConfigurations"));
                 attribute.push(hostname);

--- a/src/home.rs
+++ b/src/home.rs
@@ -60,7 +60,7 @@ impl HomeRebuildArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {
@@ -277,7 +277,7 @@ impl HomeReplArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {

--- a/src/home.rs
+++ b/src/home.rs
@@ -162,7 +162,14 @@ where
             ref reference,
             ref mut attribute,
         } => 'flake: {
-            // If user explicitely selects some other attribute, don't push homeConfigurations
+            // Check if we're using NH_HOME_FLAKE to give it precedence
+            if env::var("NH_HOME_FLAKE").is_ok()
+                && env::var("NH_HOME_FLAKE").unwrap() == reference.to_string()
+            {
+                debug!("Using NH_HOME_FLAKE: {}", reference);
+            }
+
+            // If user explicitly selects some other attribute, don't push homeConfigurations
             if !attribute.is_empty() {
                 break 'flake;
             }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -55,12 +55,21 @@ pub enum NHCommand {
 impl NHCommand {
     pub fn run(self) -> Result<()> {
         match self {
-            NHCommand::Os(args) => args.run(),
+            NHCommand::Os(args) => {
+                std::env::set_var("NH_CURRENT_COMMAND", "os");
+                args.run()
+            }
             NHCommand::Search(args) => args.run(),
             NHCommand::Clean(proxy) => proxy.command.run(),
             NHCommand::Completions(args) => args.run(),
-            NHCommand::Home(args) => args.run(),
-            NHCommand::Darwin(args) => args.run(),
+            NHCommand::Home(args) => {
+                std::env::set_var("NH_CURRENT_COMMAND", "home");
+                args.run()
+            }
+            NHCommand::Darwin(args) => {
+                std::env::set_var("NH_CURRENT_COMMAND", "darwin");
+                args.run()
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,18 @@ const NH_REV: Option<&str> = option_env!("NH_REV");
 fn main() -> Result<()> {
     let mut do_warn = false;
     if let Ok(f) = std::env::var("FLAKE") {
-        do_warn = true;
+        // Set NH_FLAKE if it's not already set
         if std::env::var("NH_FLAKE").is_err() {
             std::env::set_var("NH_FLAKE", f);
+        }
+
+        // Only warn if FLAKE is set and none of the NH_* variables are set
+        if std::env::var("NH_FLAKE").is_err()
+            && std::env::var("NH_OS_FLAKE").is_err()
+            && std::env::var("NH_HOME_FLAKE").is_err()
+            && std::env::var("NH_DARWIN_FLAKE").is_err()
+        {
+            do_warn = true;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,15 +25,15 @@ fn main() -> Result<()> {
         // Set NH_FLAKE if it's not already set
         if std::env::var("NH_FLAKE").is_err() {
             std::env::set_var("NH_FLAKE", f);
-        }
 
-        // Only warn if FLAKE is set and none of the NH_* variables are set
-        if std::env::var("NH_FLAKE").is_err()
-            && std::env::var("NH_OS_FLAKE").is_err()
-            && std::env::var("NH_HOME_FLAKE").is_err()
-            && std::env::var("NH_DARWIN_FLAKE").is_err()
-        {
-            do_warn = true;
+            // Only warn if FLAKE is set and we're using it to set NH_FLAKE
+            // AND none of the command-specific env vars are set
+            if std::env::var("NH_OS_FLAKE").is_err()
+                && std::env::var("NH_HOME_FLAKE").is_err()
+                && std::env::var("NH_DARWIN_FLAKE").is_err()
+            {
+                do_warn = true;
+            }
         }
     }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -85,7 +85,7 @@ impl OsRebuildArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {
@@ -232,7 +232,7 @@ impl OsReplArgs {
             let reference = elems.next().unwrap().to_owned();
             let attribute = elems
                 .next()
-                .map(|s| crate::installable::parse_attribute(s))
+                .map(crate::installable::parse_attribute)
                 .unwrap_or_default();
 
             Installable::Flake {

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -177,8 +178,17 @@ pub fn toplevel_for<S: AsRef<str>>(hostname: S, installable: Installable) -> Ins
 
     match res {
         Installable::Flake {
-            ref mut attribute, ..
+            ref reference,
+            ref mut attribute,
+            ..
         } => {
+            // Check if using NH_OS_FLAKE
+            if let Ok(os_flake) = env::var("NH_OS_FLAKE") {
+                if os_flake == *reference {
+                    debug!("Using NH_OS_FLAKE: {}", reference);
+                }
+            }
+
             // If user explicitly selects some other attribute, don't push nixosConfigurations
             if attribute.is_empty() {
                 attribute.push(String::from("nixosConfigurations"));


### PR DESCRIPTION
Changes as discussed with @viperML on Discord.

Makes nh aware of `NH_OS_FLAKE`, `NH_HOME_FLAKE`, and `NH_DARWIN_FLAKE` variables to override `NH_FLAKE` variable per-command, and includes some typo fixes within the code.

Tested for `os` and `home` subcommands, but I don't have a Darwin machine to test with. Override works as intended.

Supersedes #235 