### PR TITLE
search: allow caching results; new interface & local endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# NH Changelog
+
+## Unreleased
+
+### Added
+
+- Implement local caching for search results to improve performance on
+  subsequent searches and reduce network requests. Results are stored in
+  `$HOME/.cache/nh`, or in `/tmp/.cache/nh` if `$HOME` cannot be resolved.
+  - add `--use-cache` flag to enable/disable caching (default: enabled).
+  - add `--cache-duration` flag to configure cache expiration time (default:
+    3600 seconds).
+- Introduce fallback mechanisms for situations where the primary search endpoint
+  fails.
+  - add `--use-fallback` flag to enable/disable fallback search (default:
+    `true`).
+  - add `--fallback-file` flag to specify a local file (in Elasticsearch
+    response format) as a fallback data source.
+  - add `--fallback-endpoints` flag to specify custom http endpoints for
+    fallback search, supporting `{query}` and `{channel}` template variables.
+    This is useful if you are using your own search mirror.
+- Enable searching entirely from a local file using the `--fallback-file` option
+  when network searches are undesirable. User is responsible for supplying this
+  file.
+- Add environment variable counterparts for all new command-line flags.
+
+### Removed
+
+- Mark the nixos 24.05 channel as deprecated. `nh` will now error if a search is
+  attempted using a deprecated channel.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -193,6 +193,26 @@ pub struct SearchArgs {
     /// Show supported platforms for each package
     pub platforms: bool,
 
+    #[arg(long, short = 'u', env = "NH_SEARCH_USE_CACHE", value_parser = clap::builder::BoolishValueParser::new(), default_value = "true")]
+    /// Use cached results if available
+    pub use_cache: bool,
+
+    #[arg(long, short = 'd', env = "NH_SEARCH_CACHE_DURATION")]
+    /// Duration to keep cached results in seconds (default: 3600)
+    pub cache_duration: Option<u64>,
+
+    #[arg(long, short = 'f', env = "NH_SEARCH_USE_FALLBACK", value_parser = clap::builder::BoolishValueParser::new(), default_value = "true")]
+    /// Try fallback methods if primary search fails
+    pub use_fallback: bool,
+
+    #[arg(long, env = "NH_SEARCH_FALLBACK_FILE")]
+    /// Path to a local JSON file containing package information
+    pub fallback_file: Option<PathBuf>,
+
+    #[arg(long, env = "NH_SEARCH_FALLBACK_ENDPOINTS", value_delimiter = ',')]
+    /// Comma-separated list of alternative endpoints to query ({channel} and {query} are replaced)
+    pub fallback_endpoints: Vec<String>,
+
     /// Name of the package to search
     pub query: Vec<String>,
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,22 +1,28 @@
 use std::env;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::{BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::{Instant, SystemTime};
 
 use color_eyre::eyre::{bail, Context, Result};
-use elasticsearch_dsl::*;
+use elasticsearch_dsl::{Operator, Query, Search, SearchResponse, TextQueryType};
 use interface::SearchArgs;
+use once_cell::sync::Lazy;
+use owo_colors::OwoColorize;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, trace, warn};
 
-use crate::*;
+use crate::interface;
 
 const DEPRECATED_VERSIONS: &[&str] = &["nixos-24.05"];
 const DEFAULT_CACHE_DURATION: u64 = 3600; // 1 hour in seconds
 const CACHE_DIR: &str = ".cache/nh";
+const CACHE_FILE_EXT: &str = "json";
+
+static NIXOS_VERSION_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"nixos-[0-9]+\.[0-9]+").expect("Failed to compile regex"));
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(non_snake_case, dead_code)]
@@ -35,7 +41,8 @@ struct SearchResult {
     // package_maintainers: Vec<HashMap<String, String>>,
     package_description: Option<String>,
     package_longDescription: Option<String>,
-    package_hydra: (),
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_hydra: Option<()>,
     package_system: String,
     package_homepage: Vec<String>,
     package_position: Option<String>,
@@ -49,18 +56,9 @@ struct CachedResults {
     results: Vec<SearchResult>,
 }
 
-macro_rules! print_hyperlink {
-    ($text:expr, $link:expr) => {
-        print!("\x1b]8;;{}\x07", $link);
-        print!("{}", $text.underline());
-        println!("\x1b]8;;\x07");
-    };
-}
-
+/// Returns the user's home directory or fallbacks to '/tmp' if not available.
 fn get_home_dir() -> PathBuf {
-    env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+    env::var_os("HOME").map_or_else(|| PathBuf::from("/tmp"), PathBuf::from)
 }
 
 impl SearchArgs {
@@ -71,6 +69,18 @@ impl SearchArgs {
             bail!("Channel {} is not supported!", self.channel);
         }
 
+        // Start nixpkgs path lookup immediately
+        let nixpkgs_path_handle = std::thread::spawn(|| {
+            std::process::Command::new("nix")
+                .stderr(Stdio::null())
+                .args(["eval", "--raw", "-f", "<nixpkgs>", "path"])
+                .output()
+                .ok()
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+
         // Check for cached results if caching is enabled
         if self.use_cache {
             if let Some(results) = self.get_cached_results()? {
@@ -79,17 +89,94 @@ impl SearchArgs {
             }
         }
 
-        // Try to get nixpkgs path in parallel while we do the search
-        let nixpkgs_path = std::thread::spawn(|| {
-            std::process::Command::new("nix")
-                .stderr(Stdio::inherit())
-                .args(["eval", "-f", "<nixpkgs>", "path"])
-                .output()
-        });
-
         let query_s = self.query.join(" ");
         debug!(?query_s);
 
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!("nh/{}", crate::NH_VERSION))
+            .timeout(std::time::Duration::from_secs(15))
+            .pool_idle_timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("Failed to build reqwest client")?;
+
+        println!(
+            "Querying search.nixos.org, with channel {}...",
+            self.channel
+        );
+        let then = Instant::now();
+
+        let documents = match self.perform_elasticsearch_search(&client, &query_s) {
+            Ok(docs) => docs,
+            Err(e) => {
+                warn!("Primary search failed: {}", e);
+                if self.use_fallback
+                    && (self.fallback_file.is_some() || !self.fallback_endpoints.is_empty())
+                {
+                    match self.try_fallback_methods(&client, &query_s) {
+                        Ok(Some(docs)) => docs,
+                        Ok(None) => bail!("Fallback methods failed to find results"),
+                        Err(fallback_err) => {
+                            bail!(
+                                "Primary search failed: {}\nFallback failed: {}",
+                                e,
+                                fallback_err
+                            )
+                        }
+                    }
+                } else {
+                    bail!(
+                        "Primary search failed and no fallback methods available: {}",
+                        e
+                    );
+                }
+            }
+        };
+
+        let elapsed = then.elapsed();
+        debug!(?elapsed);
+
+        println!("Took {}ms", elapsed.as_millis());
+        if !documents.is_empty() {
+            println!("Most relevant results at the end");
+            println!();
+        } else {
+            println!("No results found.");
+            return Ok(());
+        }
+
+        // Cache the results in background thread if enabled
+        if self.use_cache {
+            let docs_clone = documents.clone();
+            // Extract only the needed fields for caching
+            let query = self.query.clone();
+            let channel = self.channel.clone();
+            let limit = self.limit;
+            let cache_duration = self.cache_duration;
+
+            std::thread::spawn(move || {
+                cache_results_in_background(query, channel, limit, cache_duration, docs_clone);
+            });
+        }
+
+        let nixpkgs_path = nixpkgs_path_handle
+            .join()
+            .unwrap_or(None)
+            .unwrap_or_default();
+
+        self.display_results_with_nixpkgs(documents, &nixpkgs_path)?;
+
+        Ok(())
+    }
+
+    /// Perform the primary search query against Elasticsearch endpoint
+    fn perform_elasticsearch_search(
+        &self,
+        client: &reqwest::blocking::Client,
+        query_s: &str,
+    ) -> Result<Vec<SearchResult>> {
+        let backend_version: i8 = 42;
+
+        // Pre-build the search query
         let query = Search::new().from(0).size(self.limit).query(
             Query::bool().filter(Query::term("type", "package")).must(
                 Query::dis_max()
@@ -110,7 +197,7 @@ impl SearchArgs {
                                 "flake_name^0.5",
                                 "flake_name.*^0.3",
                             ],
-                            query_s.clone(),
+                            query_s,
                         )
                         .r#type(TextQueryType::CrossFields)
                         .analyzer("whitespace")
@@ -118,111 +205,117 @@ impl SearchArgs {
                         .operator(Operator::And),
                     )
                     .query(
-                        Query::wildcard("package_attr_name", format!("*{}*", &query_s))
+                        Query::wildcard("package_attr_name", format!("*{query_s}*"))
                             .case_insensitive(true),
                     ),
             ),
         );
 
-        println!(
-            "Querying search.nixos.org, with channel {}...",
-            self.channel
-        );
-        let then = Instant::now();
-
-        let documents = if let Ok(docs) = self.perform_elasticsearch_search(&query) {
-            docs
-        } else if self.use_fallback
-            && (self.fallback_file.is_some() || !self.fallback_endpoints.is_empty())
-        {
-            match self.try_fallback_methods(&query_s) {
-                Ok(Some(docs)) => docs,
-                _ => {
-                    bail!("Failed to search using primary and fallback methods");
-                }
-            }
-        } else {
-            bail!("Failed to search and no fallback methods available");
-        };
-
-        let elapsed = then.elapsed();
-        debug!(?elapsed);
-        println!("Took {}ms", elapsed.as_millis());
-        println!("Most relevant results at the end");
-        println!();
-
-        // Cache the results if caching is enabled
-        if self.use_cache {
-            if let Err(e) = self.cache_results(&documents) {
-                warn!("Failed to cache results: {}", e);
-            }
-        }
-
-        // Get nixpkgs path for displaying results
-        let nixpkgs_path = match nixpkgs_path.join().unwrap() {
-            Ok(output) => String::from_utf8(output.stdout)
-                .unwrap_or_default()
-                .trim()
-                .to_string(),
-            Err(_) => String::new(),
-        };
-
-        self.display_results_with_nixpkgs(documents, &nixpkgs_path)?;
-
-        Ok(())
-    }
-
-    fn perform_elasticsearch_search(&self, query: &Search) -> Result<Vec<SearchResult>> {
-        let client = reqwest::blocking::Client::new();
+        // Optimize request construction
         let req = client
-            // I guess 42 is the version of the backend API
-            // TODO: have a GH action or something check if they updated this thing
             .post(format!(
-                "https://search.nixos.org/backend/latest-42-{}/_search",
-                self.channel
+                "https://search.nixos.org/backend/latest-{}-{}/_search",
+                backend_version, self.channel
             ))
-            .json(query)
-            .header("User-Agent", format!("nh/{}", crate::NH_VERSION))
-            // Hardcoded upstream
-            // https://github.com/NixOS/nixos-search/blob/744ec58e082a3fcdd741b2c9b0654a0f7fda4603/frontend/src/index.js
+            .json(&query)
             .basic_auth("aWVSALXpZv", Some("X8gPHnzL52wFEekuxsfQ9cSh"))
             .build()
             .context("building search query")?;
 
         debug!(?req);
 
+        // Execute request
         let response = client
             .execute(req)
             .context("querying the elasticsearch API")?;
 
         trace!(?response);
 
-        let parsed_response: SearchResponse = response
-            .json()
-            .context("parsing response into the elasticsearch format")?;
-        trace!(?parsed_response);
-
-        let documents = parsed_response
-            .documents::<SearchResult>()
-            .context("parsing search document")?;
-
-        Ok(documents)
-    }
-
-    fn try_fallback_methods(&self, query_s: &str) -> Result<Option<Vec<SearchResult>>> {
-        // Try local file fallback first
-        if let Some(fallback_file) = &self.fallback_file {
-            if let Ok(Some(docs)) = self.try_file_fallback(fallback_file, query_s) {
-                info!("Successfully retrieved results from fallback file");
-                return Ok(Some(docs));
-            }
+        if !response.status().is_success() {
+            bail!(
+                "Elasticsearch query failed with status: {}",
+                response.status()
+            );
         }
 
-        // Try configured endpoints
+        // Parse response directly with json() for better performance
+        let parsed_response: SearchResponse = response
+            .json()
+            .context("parsing response from elasticsearch")?;
+
+        trace!(?parsed_response);
+
+        parsed_response
+            .documents::<SearchResult>()
+            .context("parsing search document")
+    }
+
+    /// Attempts multiple fallback search methods in parallel when primary search fails.
+    fn try_fallback_methods(
+        &self,
+        client: &reqwest::blocking::Client,
+        query_s: &str,
+    ) -> Result<Option<Vec<SearchResult>>> {
+        // Try multiple fallback methods in parallel
+        let mut handles = Vec::new();
+
+        // Add file fallback if configured
+        if let Some(fallback_file) = &self.fallback_file {
+            let path = fallback_file.clone();
+            let query = query_s.to_string();
+            let limit = self.limit;
+            let cache_duration = self.cache_duration;
+            let channel = self.channel.clone();
+            handles.push(std::thread::spawn(move || {
+                let mut args = Self {
+                    query: vec![query.clone()],
+                    channel,
+                    limit,
+                    cache_duration,
+                    platforms: false,
+                    use_cache: false,
+                    use_fallback: false,
+                    fallback_file: None,
+                    fallback_endpoints: Vec::new(),
+                };
+                args.fallback_file = Some(path.clone());
+                args.try_file_fallback(&path, &query)
+            }));
+        }
+
+        // Add endpoint fallbacks in parallel
         for endpoint in &self.fallback_endpoints {
-            if let Ok(Some(docs)) = self.try_endpoint_fallback(endpoint, query_s) {
-                info!("Successfully retrieved results from fallback endpoint");
-                return Ok(Some(docs));
+            let endpoint_str = endpoint.clone();
+            let query = query_s.to_string();
+            let channel = self.channel.clone();
+            let client = client.clone();
+            let limit = self.limit;
+            let cache_duration = self.cache_duration;
+            handles.push(std::thread::spawn(move || {
+                let args = Self {
+                    query: vec![],
+                    channel,
+                    limit,
+                    cache_duration,
+                    platforms: false,
+                    use_cache: false,
+                    use_fallback: false,
+                    fallback_file: None,
+                    fallback_endpoints: Vec::new(),
+                };
+                args.try_endpoint_fallback(&client, &endpoint_str, &query)
+            }));
+        }
+
+        // Check results from all threads
+        for handle in handles {
+            let Ok(result) = handle.join().expect("Thread panicked") else {
+                continue;
+            };
+            if let Some(docs) = result {
+                if !docs.is_empty() {
+                    return Ok(Some(docs));
+                }
             }
         }
 
@@ -238,20 +331,52 @@ impl SearchArgs {
             return Ok(None);
         }
 
-        let file = File::open(path).context("opening fallback file")?;
-        let mut packages: Vec<SearchResult> =
-            serde_json::from_reader(file).context("parsing fallback file")?;
+        // Read file directly into memory
+        let mut file = File::open(path).context("opening fallback file")?;
+        let mut content = Vec::with_capacity(
+            file.metadata()
+                .map(|m| m.len() as usize)
+                .unwrap_or(1024 * 1024),
+        );
+        file.read_to_end(&mut content)
+            .context("reading fallback file")?;
 
-        // Filter by query string
+        let mut packages: Vec<SearchResult> =
+            serde_json::from_slice(&content).context("parsing fallback file with serde_json")?;
+
+        // Filter by query using lowercase for case-insensitive matching
         let query_lower = query_s.to_lowercase();
+
         packages.retain(|pkg| {
             pkg.package_attr_name.to_lowercase().contains(&query_lower)
                 || pkg.package_pname.to_lowercase().contains(&query_lower)
                 || pkg
                     .package_description
                     .as_ref()
-                    .map(|d| d.to_lowercase().contains(&query_lower))
-                    .unwrap_or(false)
+                    .map_or(false, |d| d.to_lowercase().contains(&query_lower))
+                || pkg
+                    .package_longDescription
+                    .as_ref()
+                    .map_or(false, |d| d.to_lowercase().contains(&query_lower))
+                || pkg
+                    .package_programs
+                    .iter()
+                    .any(|p| p.to_lowercase().contains(&query_lower))
+        });
+
+        // Sort by relevance - prioritize exact matches in attr_name
+        packages.sort_unstable_by(|a, b| {
+            let a_exact = a.package_attr_name.to_lowercase() == query_lower;
+            let b_exact = b.package_attr_name.to_lowercase() == query_lower;
+
+            if a_exact != b_exact {
+                return b_exact.cmp(&a_exact);
+            }
+
+            let a_contains = a.package_attr_name.to_lowercase().contains(&query_lower);
+            let b_contains = b.package_attr_name.to_lowercase().contains(&query_lower);
+
+            b_contains.cmp(&a_contains)
         });
 
         // Limit results
@@ -268,6 +393,7 @@ impl SearchArgs {
 
     fn try_endpoint_fallback(
         &self,
+        client: &reqwest::blocking::Client,
         endpoint: &str,
         query_s: &str,
     ) -> Result<Option<Vec<SearchResult>>> {
@@ -275,121 +401,141 @@ impl SearchArgs {
             .replace("{channel}", &self.channel)
             .replace("{query}", query_s);
 
-        match reqwest::blocking::get(&request_url) {
-            Ok(response) => {
-                if response.status().is_success() {
-                    if let Ok(packages) = response.json::<Vec<SearchResult>>() {
-                        // Filter packages by query if needed
-                        let mut filtered_packages = packages;
+        debug!("Trying fallback endpoint: {}", request_url);
 
-                        // Limit results
-                        if filtered_packages.len() > self.limit as usize {
-                            filtered_packages.truncate(self.limit as usize);
-                        }
+        let response = client
+            .get(&request_url)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .context(format!("sending request to fallback endpoint: {endpoint}"))?;
 
-                        if !filtered_packages.is_empty() {
-                            return Ok(Some(filtered_packages));
-                        }
+        if response.status().is_success() {
+            match response.json::<Vec<SearchResult>>() {
+                Ok(mut packages) => {
+                    if packages.len() > self.limit as usize {
+                        packages.truncate(self.limit as usize);
+                    }
+                    if !packages.is_empty() {
+                        Ok(Some(packages))
+                    } else {
+                        Ok(None)
                     }
                 }
+                Err(e) => {
+                    warn!("Failed to parse JSON from endpoint {}: {}", endpoint, e);
+                    Ok(None)
+                }
             }
-            Err(e) => {
-                debug!("Fallback endpoint {} failed: {}", endpoint, e);
-            }
+        } else {
+            Ok(None)
         }
-
-        Ok(None)
     }
 
     fn get_cache_path(&self) -> Result<PathBuf> {
-        let cache_dir = get_home_dir().join(CACHE_DIR);
-        fs::create_dir_all(&cache_dir).context("creating cache directory")?;
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
-        // Create a filename based on channel and query
         let query_hash = {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
             let mut hasher = DefaultHasher::new();
             self.query.hash(&mut hasher);
             self.channel.hash(&mut hasher);
+            self.limit.hash(&mut hasher);
             hasher.finish()
         };
 
-        Ok(cache_dir.join(format!("search_{}_{}.json", self.channel, query_hash)))
+        let cache_dir = get_home_dir().join(CACHE_DIR);
+
+        // Create directory only if needed
+        if !cache_dir.exists() {
+            fs::create_dir_all(&cache_dir).context("creating cache directory")?;
+        }
+
+        Ok(cache_dir.join(format!(
+            "search_{}_{}.{}",
+            self.channel, query_hash, CACHE_FILE_EXT
+        )))
     }
 
     fn get_cached_results(&self) -> Result<Option<Vec<SearchResult>>> {
         let cache_path = match self.get_cache_path() {
             Ok(path) => path,
-            Err(_) => return Ok(None),
+            Err(e) => {
+                warn!("Failed to get cache path: {}", e);
+                return Ok(None);
+            }
         };
 
         if !cache_path.exists() {
             return Ok(None);
         }
 
+        // Read file directly into memory for better performance
         let mut file = match File::open(&cache_path) {
             Ok(file) => file,
-            Err(_) => return Ok(None),
+            Err(e) => {
+                warn!("Failed to open cache file {}: {}", cache_path.display(), e);
+                let _ = fs::remove_file(&cache_path);
+                return Ok(None);
+            }
         };
 
-        let mut contents = String::new();
-        if file.read_to_string(&mut contents).is_err() {
+        let metadata = file.metadata().ok();
+        let file_size = metadata.as_ref().map_or(0, |m| m.len() as usize);
+        let mut content = Vec::with_capacity(file_size.max(1024));
+
+        if let Err(e) = file.read_to_end(&mut content) {
+            warn!("Failed to read cache file {}: {}", cache_path.display(), e);
+            let _ = fs::remove_file(&cache_path);
             return Ok(None);
         }
 
-        let cached: CachedResults = match serde_json::from_str(&contents) {
+        let cached: CachedResults = match serde_json::from_slice(&content) {
             Ok(cached) => cached,
-            Err(_) => return Ok(None),
+            Err(e) => {
+                warn!("Failed to parse cache: {}, removing file", e);
+                let _ = fs::remove_file(&cache_path);
+                return Ok(None);
+            }
         };
 
         // Check if cache is still valid
         let cache_duration = self.cache_duration.unwrap_or(DEFAULT_CACHE_DURATION);
         match cached.timestamp.elapsed() {
             Ok(elapsed) if elapsed.as_secs() <= cache_duration => {
-                info!(
-                    "Using cached results from {} seconds ago",
-                    elapsed.as_secs()
-                );
+                info!("Using cached results from {}s ago", elapsed.as_secs());
                 Ok(Some(cached.results))
             }
-            _ => {
-                // Cache is expired or timestamp error
+            Ok(_) => {
+                // Remove expired cache file in background
+                // "Cache invalidation and naming things"
+                let path = cache_path;
+                std::thread::spawn(move || {
+                    let _ = fs::remove_file(path);
+                });
                 Ok(None)
             }
+            Err(_) => Ok(None),
         }
     }
 
-    fn cache_results(&self, results: &[SearchResult]) -> Result<()> {
-        let cache_path = self.get_cache_path()?;
-
-        let cached = CachedResults {
-            timestamp: SystemTime::now(),
-            channel: self.channel.clone(),
-            query: self.query.clone(),
-            results: results.to_vec(),
-        };
-
-        let json = serde_json::to_string(&cached)?;
-        let mut file = File::create(cache_path)?;
-        file.write_all(json.as_bytes())?;
-
-        Ok(())
-    }
-
     fn display_results(&self, results: Vec<SearchResult>) -> Result<()> {
-        // Try to get nixpkgs path for displaying results
-        let nixpkgs_path = match std::process::Command::new("nix")
-            .stderr(Stdio::inherit())
-            .args(["eval", "-f", "<nixpkgs>", "path"])
-            .output()
-        {
-            Ok(output) => String::from_utf8(output.stdout)
-                .unwrap_or_default()
-                .trim()
-                .to_string(),
-            Err(_) => String::new(),
-        };
+        // Get nixpkgs path without blocking for too long
+        let nixpkgs_path = std::thread::spawn(|| {
+            let output = std::process::Command::new("nix")
+                .stderr(Stdio::null())
+                .args(["eval", "--raw", "-f", "<nixpkgs>", "path"])
+                .output();
+
+            match output {
+                Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+                _ => String::new(),
+            }
+        })
+        .join()
+        .unwrap_or_else(|_| String::new());
 
         self.display_results_with_nixpkgs(results, &nixpkgs_path)
     }
@@ -399,69 +545,177 @@ impl SearchArgs {
         results: Vec<SearchResult>,
         nixpkgs_path: &str,
     ) -> Result<()> {
+        if results.is_empty() {
+            println!("No results found.");
+            return Ok(());
+        }
+
         let hyperlinks = supports_hyperlinks::supports_hyperlinks();
         debug!(?hyperlinks);
+        let term_width = textwrap::termwidth();
+
+        // Use larger buffer for stdout
+        let stdout = std::io::stdout();
+        let mut writer = BufWriter::with_capacity(65536, stdout.lock());
 
         for elem in results.iter().rev() {
-            println!();
-            use owo_colors::OwoColorize;
-            trace!("{elem:#?}");
+            writeln!(writer)?;
 
-            print!("{}", elem.package_attr_name.blue());
+            write!(writer, "{}", elem.package_attr_name.blue())?;
             let v = &elem.package_pversion;
             if !v.is_empty() {
-                print!(" ({})", v.green());
+                write!(writer, " ({})", v.green())?;
             }
-
-            println!();
+            writeln!(writer)?;
 
             if let Some(ref desc) = elem.package_description {
                 let desc = desc.replace('\n', " ");
-                for line in textwrap::wrap(&desc, textwrap::Options::with_termwidth()) {
-                    println!("  {}", line);
+                if desc.len() < term_width - 2 {
+                    writeln!(writer, "  {desc}")?;
+                } else {
+                    let wrap_options = textwrap::Options::new(term_width)
+                        .initial_indent("  ")
+                        .subsequent_indent("  ");
+                    for line in textwrap::wrap(&desc, wrap_options) {
+                        writeln!(writer, "{line}")?;
+                    }
                 }
             }
 
-            for url in elem.package_homepage.iter() {
-                print!("  Homepage: ");
+            for url in &elem.package_homepage {
+                if url.is_empty() {
+                    continue;
+                }
+                write!(writer, "  Homepage: ")?;
                 if hyperlinks {
-                    print_hyperlink!(url, url);
+                    write!(writer, "\x1b]8;;{url}\x07")?;
+                    write!(writer, "{}", url.underline())?;
+                    writeln!(writer, "\x1b]8;;\x07")?;
                 } else {
-                    println!("{}", url);
+                    writeln!(writer, "{url}")?;
                 }
             }
 
             if self.platforms && !elem.package_platforms.is_empty() {
-                println!("  Platforms: {}", elem.package_platforms.join(", "));
+                write!(writer, "  Platforms: ")?;
+                // Write platforms without allocating a new joined string
+                for (i, platform) in elem.package_platforms.iter().enumerate() {
+                    if i > 0 {
+                        write!(writer, ", ")?;
+                    }
+                    write!(writer, "{platform}")?;
+                }
+                writeln!(writer)?;
             }
 
             if let Some(position) = &elem.package_position {
-                if !nixpkgs_path.is_empty() {
-                    let position = position.split(':').next().unwrap();
-                    print!("  Defined at: ");
-                    if hyperlinks {
-                        let position_trimmed = position
-                            .split(':')
-                            .next()
-                            .expect("Removing line number from position");
-
-                        print_hyperlink!(
-                            position,
-                            format!("file://{}/{}", nixpkgs_path, position_trimmed)
-                        );
-                    } else {
-                        println!("{}", position);
+                if !position.is_empty() && !nixpkgs_path.is_empty() {
+                    if let Some(file_part) = position.split(':').next() {
+                        if !file_part.is_empty() {
+                            write!(writer, "  Defined at: ")?;
+                            if hyperlinks {
+                                let full_file_path = format!("file://{nixpkgs_path}/{file_part}");
+                                write!(writer, "\x1b]8;;{full_file_path}\x07")?;
+                                write!(writer, "{}", position.underline())?;
+                                writeln!(writer, "\x1b]8;;\x07")?;
+                            } else {
+                                writeln!(writer, "{position}")?;
+                            }
+                        }
                     }
                 }
             }
         }
-
+        writer.flush()?;
         Ok(())
     }
 }
 
+/// Asynchronously caches search results to disk in the background
+/// to avoid blocking the main thread.
+fn cache_results_in_background(
+    query: Vec<String>,
+    channel: String,
+    limit: u64,
+    _cache_duration: Option<u64>,
+    results: Vec<SearchResult>,
+) {
+    // Create a new function to avoid borrowing self
+    fn get_cache_path(query: &[String], channel: &str, limit: u64) -> Result<PathBuf> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let query_hash = {
+            let mut hasher = DefaultHasher::new();
+            query.hash(&mut hasher);
+            channel.hash(&mut hasher);
+            limit.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let cache_dir = get_home_dir().join(CACHE_DIR);
+
+        if !cache_dir.exists() {
+            fs::create_dir_all(&cache_dir)?;
+        }
+
+        Ok(cache_dir.join(format!("search_{channel}_{query_hash}.{CACHE_FILE_EXT}")))
+    }
+
+    match get_cache_path(&query, &channel, limit) {
+        Ok(cache_path) => {
+            let cached = CachedResults {
+                timestamp: SystemTime::now(),
+                channel,
+                query,
+                results,
+            };
+
+            // Create parent directories if needed
+            if let Some(parent) = cache_path.parent() {
+                if !parent.exists() {
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        warn!("Failed to create cache directory: {}", e);
+                        return;
+                    }
+                }
+            }
+
+            // Use atomic file operation with temp file
+            let temp_path = cache_path.with_extension("tmp");
+
+            match File::create(&temp_path) {
+                Ok(file) => {
+                    let writer = BufWriter::with_capacity(32768, file);
+                    if let Err(e) = serde_json::to_writer(writer, &cached) {
+                        warn!("Failed to serialize cache results: {}", e);
+                        return;
+                    }
+
+                    if let Err(e) = fs::rename(temp_path, cache_path) {
+                        warn!("Failed to move temp cache file: {}", e);
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to create cache file: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Failed to determine cache path: {}", e);
+        }
+    }
+}
+
+/// Verifies if a NixOS branch/channel is supported
+/// by checking against known patterns and deprecated versions.
 fn supported_branch<S: AsRef<str>>(branch: S) -> bool {
     let branch = branch.as_ref();
+
+    // Fast path for common case
+    if branch == "nixos-unstable" {
+        return true;
+    }
 
     // Check against deprecated versions list
     if DEPRECATED_VERSIONS.contains(&branch) {
@@ -469,12 +723,7 @@ fn supported_branch<S: AsRef<str>>(branch: S) -> bool {
         return false;
     }
 
-    if branch == "nixos-unstable" {
-        return true;
-    }
-
-    let re = Regex::new(r"nixos-[0-9]+\.[0-9]+").unwrap();
-    re.is_match(branch)
+    NIXOS_VERSION_REGEX.is_match(branch)
 }
 
 #[test]


### PR DESCRIPTION
Includes three new changes: channel deprecation, result caching, and fallback search methods. Additionally, those changes are documented in a newly added changelog.

## Changes

We now mark NixOS 24.05 as deprecated, and hard-error if the user attempts to search with a deprecated channnel; NixOS considers those insecure, and so should we.

More importantly, search results can now be cached locally to help with performance of subsequent searches, and reduce network requests. With long cache durations, it might even be possible to support *fully* offline search but I have different ideas on how to approach this. The cache system stores results in the `$HOME/.cache/nh` directory with filenames based on a hash of the query and channel. Cache entries include timestamps and expire after 3600 seconds by default, though this duration is configurable via the new `--cache-duration` option. Users can toggle caching with the `--use-cache` flag. Worth nothing that the cache files are *not* cleaned automatically, maybe the nh module can handle that.

When primary elasticsearch searches fail (happens more often than I'd like to see), the system can now fall back to alternative methods. These include checking a local file specified by `--fallback-file` or querying custom endpoints provided through `--fallback-endpoints`. Fallback endpoints support template variables like `{channel}` and `{query}` for dynamic requests. This mechanism is activated only if the primary search fails and can be disabled with `--use-fallback=false` if so desired.

I've also went ahead and added corresponding environment variables for persistent configuration in the light of Viper's vision.

### Local Search

I made it possible to search locally if you want to avoid network searches. For consistency, the file format should be the same as the Elasticsearch response format

```json
[
  {
    "package_attr_name": "packageName",
    "package_attr_set": "nixpkgs",
    "package_pname": "package-name",
    "package_pversion": "1.2.3",
    "package_platforms": ["x86_64-linux", "aarch64-linux"],
    "package_outputs": ["out", "dev"],
    "package_default_output": "out",
    "package_programs": ["program1", "program2"],
    "package_license_set": ["MIT"],
    "package_description": "A short description.",
    "package_longDescription": "A longer description that might contain more details.",
    "package_hydra": null,
    "package_system": "x86_64-linux",
    "package_homepage": ["https://example.com"],
    "package_position": "pkgs/tools/misc/packageName/default.nix:123"
  },
  {
    "package_attr_name": "anotherPackage",
    "package_attr_set": "nixpkgs",
    "package_pname": "another-package",
    "package_pversion": "0.1.0",
    "package_platforms": ["x86_64-darwin"],
    "package_outputs": ["out"],
    "package_default_output": null,
    "package_programs": [],
    "package_license_set": ["GPLv3"],
    "package_description": null,
    "package_longDescription": null,
    "package_hydra": null,
    "package_system": "x86_64-darwin",
    "package_homepage": [],
    "package_position": null
  }
]
```