### PR TITLE
use SUDO_ASKPASS program if set

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -84,8 +84,9 @@ impl Command {
             };
 
             // use NH_SUDO_ASKPASS program for sudo if present
-            let cmd = if std::env::var("NH_SUDO_ASKPASS").is_ok() {
-                cmd.arg("-A")
+            let askpass = std::env::var("NH_SUDO_ASKPASS");
+            let cmd = if let Ok(askpass) = askpass {
+                cmd.env("SUDO_ASKPASS", askpass).arg("-A")
             } else {
                 cmd
             };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -83,8 +83,8 @@ impl Command {
                 Exec::cmd("sudo")
             };
 
-            // use SUDO_ASKPASS program for sudo if present
-            let cmd = if std::env::var("SUDO_ASKPASS").is_ok() {
+            // use NH_SUDO_ASKPASS program for sudo if present
+            let cmd = if std::env::var("NH_SUDO_ASKPASS").is_ok() {
                 cmd.arg("-A")
             } else {
                 cmd

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -83,6 +83,13 @@ impl Command {
                 Exec::cmd("sudo")
             };
 
+            // use SUDO_ASKPASS program for sudo if present
+            let cmd = if std::env::var("SUDO_ASKPASS").is_ok() {
+                cmd.arg("-A")
+            } else {
+                cmd
+            };
+
             cmd.arg(&self.command).args(&self.args)
         } else {
             Exec::cmd(&self.command).args(&self.args)

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ fn self_elevate() -> ! {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = std::process::Command::new("sudo");
-    // use SUDO_ASKPASS program for sudo if present
-    if std::env::var("SUDO_ASKPASS").is_ok() {
+    // use NH_SUDO_ASKPASS program for sudo if present
+    if std::env::var("NH_SUDO_ASKPASS").is_ok() {
         cmd.arg("-A");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,11 @@ fn self_elevate() -> ! {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = std::process::Command::new("sudo");
+    // use SUDO_ASKPASS program for sudo if present
+    if std::env::var("SUDO_ASKPASS").is_ok() {
+        cmd.arg("-A");
+    }
+
     cmd.args(std::env::args());
     debug!("{:?}", cmd);
     let err = cmd.exec();

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,11 @@ fn self_elevate() -> ! {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = std::process::Command::new("sudo");
+
     // use NH_SUDO_ASKPASS program for sudo if present
-    if std::env::var("NH_SUDO_ASKPASS").is_ok() {
-        cmd.arg("-A");
+    let askpass = std::env::var("NH_SUDO_ASKPASS");
+    if let Ok(askpass) = askpass {
+        cmd.env("SUDO_ASKPASS", askpass).arg("-A");
     }
 
     cmd.args(std::env::args());


### PR DESCRIPTION
A GUI based popup seems more "intuitive" when calling `sudo` internally, as the application just asking for password with sudo on terminal "feels" like hijacking the program. Ofcourse that is not the case, it is completely personal opinion, but you may want to consider this.

Also for those with `sudo` enabled with fingerprint access, it is much more difficult to deal with terminal, as default configuration makes you go for "three fingerprint attempts" before it asks you for password. So if you do not want to use fingerprint, but password instead, normally for programs running with `sudo` (say `sudo echo hello`), you can just <kbd>Ctrl</kbd>+<kbd>C</kbd> during the first attempt, and then password input appears. But since `nh` calls it internally, <kbd>Ctrl</kbd>+<kbd>C</kbd> just halts the execution instead of `nh` instead of letting `sudo` handle it.

Hence running `sudo` with `-A` flag makes sense. But since not everyone have a askpass setup right away, one can conditionally check for the environment variable `SUDO_ASKPASS` (at runtime), and if set, then run `sudo` with `-A` flag to let the ask pass program handle password entry stuff in more "elegant" way.

It will be convenient to both `SUDO_ASKPASS` users and non-users since it will be checked to trigger `sudo`, and hence experience will either remain the same or improve.

Here is an example configuration for nixos for `SUDO_ASKPASS` config which presents a GUI prompt, and if GUI is not available (say running from tty) password is input fallback is done on terminal.

```nix
{ config, pkgs, ... }:
{
  environment.sessionVariables =
    let
      prompt = "Input password for elevated privilages";
      gui-askpass =
        if config.programs.ssh.enableAskPassword then
          "${config.programs.ssh.askPassword} '${prompt}'"
        else
          "${pkgs.zenity}/bin/zenity --password --title='${prompt}'";
      wrapped-askpass = pkgs.writeScriptBin "sudo-askpass" ''
        #!/usr/bin/env sh
        ${gui-askpass} || (read -s -p 'Input Password: ' password && echo $password && unset password)
      '';
    in
    {
      SUDO_ASKPASS = "${wrapped-askpass}/bin/sudo-askpass";
    };
}
```