### PR TITLE
home: ensure `--configuration` is correctly passed to switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
+<!-- markdownlint-disable no-duplicate-headings -->
+
 # NH Changelog
+
+## 4.0.3
+
+### Added
+
+- Nh now supports specifying `NH_SUDO_ASKPASS` to pass a custom value to
+  `SUDO_ASKPASS` in self-elevation. If specified, `sudo` will be called with
+  `-A` and the `NH_SUDO_ASKPASS` will be `SUDO_ASKPASS` locally.
+
+### Fixed
+
+- Fix `--configuration` being ignored in `nh home switch`
+  ([#262](https://github.com/nix-community/nh/issues/262))
 
 ## 4.0.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nh"
-version = "4.0.2"
+version = "4.0.3"
 dependencies = [
  "anstyle",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nh"
-version = "4.0.2"
+version = "4.0.3"
 edition = "2021"
 license = "EUPL-1.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is a little dirty for my taste, but it fixes the regression inbetween 3.6.0 and the 4.0.0 releases. Not sure where the regression was introduced, but from what I can tell the latest 4.0.0 beta does not have the logic to parse `--configuration` so it's definitely @viperML's fault and not mine. Trust :pray:

I've also made home switch a little more verbose and improved existing implementation where it caught my attention.

Fixes #262 