### PR TITLE
nixos: implement rollbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- A new `nh os rollback` subcommand has been added to allow rolling back a
+  generation, or to a specific generation with the `--to` flag. See
+  `nh os rollback --help` for more details on this subcommand.
+
 - Nh now supports the `--build-host` and `--target-host` cli arguments
 
 - Nh now checks if the current Nix implementation has necessary experimental
@@ -22,7 +26,8 @@
 
 - Darwin: Use `darwin-rebuild` directly for activation instead of old scripts
 - Darwin: Future-proof handling of `activate-user` script removal
-- Darwin: Improve compatibility with root-only activation in newer nix-darwin versions
+- Darwin: Improve compatibility with root-only activation in newer nix-darwin
+  versions
 
 ## 4.0.3
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -103,6 +103,9 @@ pub enum OsSubcommand {
 
     /// List available generations from profile path
     Info(OsGenerationsArgs),
+
+    /// Rollback to a previous generation
+    Rollback(OsRollbackArgs),
 }
 
 #[derive(Debug, Args)]
@@ -140,6 +143,33 @@ pub struct OsRebuildArgs {
     /// Build the configuration to a different host over ssh
     #[arg(long)]
     pub build_host: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OsRollbackArgs {
+    /// Only print actions, without performing them
+    #[arg(long, short = 'n')]
+    pub dry: bool,
+
+    /// Ask for confirmation
+    #[arg(long, short)]
+    pub ask: bool,
+
+    /// Explicitly select some specialisation
+    #[arg(long, short)]
+    pub specialisation: Option<String>,
+
+    /// Ignore specialisations
+    #[arg(long, short = 'S')]
+    pub no_specialisation: bool,
+
+    /// Rollback to a specific generation number (defaults to previous generation)
+    #[arg(long, short)]
+    pub to: Option<u64>,
+
+    /// Don't panic if calling nh as root
+    #[arg(short = 'R', long, env = "NH_BYPASS_ROOT_CHECK")]
+    pub bypass_root_check: bool,
 }
 
 #[derive(Debug, Args)]


### PR DESCRIPTION
Implement `nh os rollback`. This is implemented as a subcommand and not a flag, because I do not want to parse different cli flag combinations on top of `nh os switch`.

Closes #30