### PR TITLE
nixos: add `--target-host` and `--build-host` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # NH Changelog
 
+## Unreleased
+
+### Added
+
+- Nh now supports the `--build-host` and `--target-host` cli arguments
+
 ## 4.0.3
 
 ### Added

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,7 +8,7 @@ use subprocess::{Exec, ExitStatus, Redirection};
 use thiserror::Error;
 use tracing::{debug, info};
 
-use crate::{installable::Installable, util::get_current_system};
+use crate::installable::Installable;
 
 fn ssh_wrap(cmd: Exec, ssh: Option<&str>) -> Exec {
     if let Some(ssh) = ssh {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,19 +4,20 @@ use color_eyre::{
     eyre::{bail, Context},
     Result,
 };
-use subprocess::{Exec, ExitStatus, Pipeline, Redirection};
+use subprocess::{Exec, ExitStatus, Redirection};
 use thiserror::Error;
 use tracing::{debug, info};
 
 use crate::{installable::Installable, util::get_current_system};
 
-// for some reason there isnt a common trait that both Exec and Pipeline implements, so just use
-// the no op : from bash
-fn ssh_wrap(cmd: Exec, ssh: Option<&str>) -> Pipeline {
+fn ssh_wrap(cmd: Exec, ssh: Option<&str>) -> Exec {
     if let Some(ssh) = ssh {
-        Exec::cmd("echo").arg(cmd.to_cmdline_lossy().as_str()) | Exec::cmd("ssh").arg("-T").arg(ssh)
+        Exec::cmd("ssh")
+            .arg("-T")
+            .arg(ssh)
+            .stdin(cmd.to_cmdline_lossy().as_str())
     } else {
-        Exec::cmd(":") | cmd
+        cmd
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -218,10 +218,9 @@ impl Build {
                     .args(&installable_args)
                     .args(&["--log-format", "internal-json", "--verbose"])
                     .args(&match &self.builder {
-                        Some(host) => vec![
-                            "--builders".to_string(),
-                            format!("ssh://{host} {} - - 100", get_current_system().unwrap()),
-                        ],
+                        Some(host) => {
+                            vec!["--builders".to_string(), format!("ssh://{host} - - - 100")]
+                        }
                         None => vec![],
                     })
                     .args(&self.extra_args)

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -136,6 +136,10 @@ pub struct OsRebuildArgs {
     /// Deploy the configuration to a different host over ssh
     #[arg(long)]
     pub target_host: Option<String>,
+
+    /// Build the configuration to a different host over ssh
+    #[arg(long)]
+    pub build_host: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -132,6 +132,10 @@ pub struct OsRebuildArgs {
     /// Don't panic if calling nh as root
     #[arg(short = 'R', long, env = "NH_BYPASS_ROOT_CHECK")]
     pub bypass_root_check: bool,
+
+    /// Deploy the configuration to a different host over ssh
+    #[arg(long)]
+    pub target_host: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -13,6 +13,7 @@ use crate::installable::Installable;
 use crate::interface::OsSubcommand::{self};
 use crate::interface::{self, OsGenerationsArgs, OsRebuildArgs, OsReplArgs};
 use crate::update::update;
+use crate::util::ensure_ssh_key_login;
 use crate::util::get_hostname;
 
 const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
@@ -50,6 +51,10 @@ enum OsRebuildVariant {
 impl OsRebuildArgs {
     fn rebuild(self, variant: OsRebuildVariant) -> Result<()> {
         use OsRebuildVariant::*;
+
+        if self.build_host.is_some() || self.target_host.is_some() {
+            ensure_ssh_key_login().unwrap();
+        }
 
         let elevate = if self.bypass_root_check {
             warn!("Bypassing root check, now running nix as root");

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -53,7 +53,8 @@ impl OsRebuildArgs {
         use OsRebuildVariant::*;
 
         if self.build_host.is_some() || self.target_host.is_some() {
-            ensure_ssh_key_login().unwrap();
+            // if it fails its okay
+            let _ = ensure_ssh_key_login();
         }
 
         let elevate = if self.bypass_root_check {

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -122,6 +122,8 @@ impl OsRebuildArgs {
             Some(spec) => out_path.get_path().join("specialisation").join(spec),
         };
 
+        debug!("exists: {}", target_profile.exists());
+
         target_profile.try_exists().context("Doesn't exist")?;
 
         if self.build_host.is_none() && self.target_host.is_none() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,6 +59,26 @@ pub fn get_nix_version() -> Result<String> {
     Err(eyre::eyre!("Failed to extract version"))
 }
 
+/// Retrieves the current system we're running on in the format nix expects
+///
+/// This functions just runs `nix eval --impure --raw --expr 'builtins.currentSystem'` and gets the
+/// output
+///
+/// * `Result<String>` - The current system string or an error if the version cannot be retrieved.
+pub fn get_current_system() -> Result<String> {
+    let output = Command::new("nix")
+        .args([
+            "eval",
+            "--impure",
+            "--raw",
+            "--expr",
+            "builtins.currentSystem",
+        ])
+        .output()?;
+    let output_str = str::from_utf8(&output.stdout)?;
+    Ok(output_str.to_string())
+}
+
 pub trait MaybeTempPath: std::fmt::Debug {
     fn get_path(&self) -> &Path;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 extern crate semver;
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::str;
 
 use color_eyre::{eyre, Result};
@@ -77,6 +77,27 @@ pub fn get_current_system() -> Result<String> {
         .output()?;
     let output_str = str::from_utf8(&output.stdout)?;
     Ok(output_str.to_string())
+}
+
+/// Prompts the user for ssh key login if needed
+pub fn ensure_ssh_key_login() -> Result<()> {
+    // ssh-add -L checks if there are any currently usable ssh keys
+
+    if Command::new("ssh-add")
+        .arg("-L")
+        .stdout(Stdio::null())
+        .status()?
+        .success()
+    {
+        return Ok(());
+    }
+    Command::new("ssh-add")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()?
+        .wait()?;
+    Ok(())
 }
 
 pub trait MaybeTempPath: std::fmt::Debug {

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,26 +59,6 @@ pub fn get_nix_version() -> Result<String> {
     Err(eyre::eyre!("Failed to extract version"))
 }
 
-/// Retrieves the current system we're running on in the format nix expects
-///
-/// This functions just runs `nix eval --impure --raw --expr 'builtins.currentSystem'` and gets the
-/// output
-///
-/// * `Result<String>` - The current system string or an error if the version cannot be retrieved.
-pub fn get_current_system() -> Result<String> {
-    let output = Command::new("nix")
-        .args([
-            "eval",
-            "--impure",
-            "--raw",
-            "--expr",
-            "builtins.currentSystem",
-        ])
-        .output()?;
-    let output_str = str::from_utf8(&output.stdout)?;
-    Ok(output_str.to_string())
-}
-
 /// Prompts the user for ssh key login if needed
 pub fn ensure_ssh_key_login() -> Result<()> {
     // ssh-add -L checks if there are any currently usable ssh keys

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command as StdCommand, Stdio};
 use std::str;
 
 use color_eyre::{eyre, Result};
@@ -46,7 +46,7 @@ pub fn get_nix_version() -> Result<String> {
 pub fn ensure_ssh_key_login() -> Result<()> {
     // ssh-add -L checks if there are any currently usable ssh keys
 
-    if Command::new("ssh-add")
+    if StdCommand::new("ssh-add")
         .arg("-L")
         .stdout(Stdio::null())
         .status()?
@@ -54,7 +54,7 @@ pub fn ensure_ssh_key_login() -> Result<()> {
     {
         return Ok(());
     }
-    Command::new("ssh-add")
+    StdCommand::new("ssh-add")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
part of #254

not sure if the right move here is to invoke `ln -s` over ssh to make sure the out_path is symlinked correctly on the target machine, or if just canonicalize'ing the paths is the right move, i went for canonicalize just because it felt less hacky than invoking `ln -s` over ssh

it currently works for me on my own local server