### PR TITLE
treewide: consolidate logic in platform-specific commands

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -72,8 +72,8 @@ impl DarwinRebuildArgs {
         debug!(?out_path);
 
         // Resolve the installable from env var or from the provided argument
-        let installable =
-            platform::resolve_env_installable("NH_DARWIN_FLAKE", self.common.installable.clone());
+        let installable = platform::resolve_env_installable("NH_DARWIN_FLAKE")
+            .unwrap_or_else(|| self.common.installable.clone());
 
         // Build the darwin configuration with proper attribute path handling
         let target_profile = platform::handle_rebuild_workflow(
@@ -151,7 +151,8 @@ impl DarwinReplArgs {
 
         // Open an interactive REPL session for exploring darwin configurations
         platform::run_repl(
-            platform::resolve_env_installable("NH_DARWIN_FLAKE", self.installable),
+            platform::resolve_env_installable("NH_DARWIN_FLAKE")
+                .unwrap_or_else(|| self.installable),
             "darwinConfigurations",
             &[], // REPL doesn't need additional path elements
             Some(hostname),

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -9,10 +9,18 @@ use crate::util::get_hostname;
 use crate::util::platform;
 use crate::Result;
 
+/// System profile path for darwin configurations
 const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
+/// Current system profile path for darwin
 const CURRENT_PROFILE: &str = "/run/current-system";
 
 impl DarwinArgs {
+    /// Entry point for processing darwin commands
+    ///
+    /// Handles the different subcommands for darwin configurations:
+    /// - Switch: Builds and activates the configuration
+    /// - Build: Only builds the configuration
+    /// - Repl: Opens a REPL for exploring the configuration
     pub fn run(self) -> Result<()> {
         use DarwinRebuildVariant::{Build, Switch};
         match self.subcommand {
@@ -28,12 +36,25 @@ impl DarwinArgs {
     }
 }
 
+/// Variants of the darwin rebuild operation
+///
+/// Each variant represents a different mode of operation:
+/// - Switch: Build and activate the configuration
+/// - Build: Only build the configuration without activation
 enum DarwinRebuildVariant {
     Switch,
     Build,
 }
 
 impl DarwinRebuildArgs {
+    /// Performs the rebuild operation for darwin configurations
+    ///
+    /// This function handles building and potentially activating darwin configurations.
+    /// It first builds the configuration, then shows a diff of changes compared to the
+    /// current system, and finally activates the configuration if needed.
+    ///
+    /// The darwin activation process is unique and requires special handling compared
+    /// to `NixOS`, particularly around determining whether root privileges are needed.
     fn rebuild(self, variant: DarwinRebuildVariant) -> Result<()> {
         use DarwinRebuildVariant::{Build, Switch};
 
@@ -117,6 +138,10 @@ impl DarwinRebuildArgs {
 }
 
 impl DarwinReplArgs {
+    /// Opens a Nix REPL for exploring darwin configurations
+    ///
+    /// Provides an interactive environment to explore and evaluate
+    /// components of a darwin configuration.
     fn run(self) -> Result<()> {
         if let Installable::Store { .. } = self.installable {
             bail!("Nix doesn't support nix store installables.");

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -43,7 +43,7 @@ pub fn from_dir(generation_dir: &Path) -> Option<u64> {
         })
 }
 
-pub fn describe(generation_dir: &Path, current_profile: &Path) -> Option<GenerationInfo> {
+pub fn describe(generation_dir: &Path, _current_profile: &Path) -> Option<GenerationInfo> {
     let generation_number = from_dir(generation_dir)?;
 
     // Get metadata once and reuse for both date and existence checks

--- a/src/home.rs
+++ b/src/home.rs
@@ -67,8 +67,8 @@ impl HomeRebuildArgs {
         debug!(?out_path);
 
         // Use NH_HOME_FLAKE if available, otherwise use the provided installable
-        let installable =
-            platform::resolve_env_installable("NH_HOME_FLAKE", self.common.installable.clone());
+        let installable = platform::resolve_env_installable("NH_HOME_FLAKE")
+            .unwrap_or_else(|| self.common.installable.clone());
 
         // Set up the specialisation path
         let spec_location =
@@ -168,7 +168,8 @@ impl HomeReplArgs {
     /// debugging or exploring available options.
     fn run(self) -> Result<()> {
         // Use NH_HOME_FLAKE if available, otherwise use the provided installable
-        let installable = platform::resolve_env_installable("NH_HOME_FLAKE", self.installable);
+        let installable =
+            platform::resolve_env_installable("NH_HOME_FLAKE").unwrap_or_else(|| self.installable);
 
         // Launch an interactive REPL session for exploring the configuration
         platform::run_repl(

--- a/src/home.rs
+++ b/src/home.rs
@@ -121,14 +121,14 @@ impl HomeRebuildArgs {
             Some(spec) => Box::new(out_path.get_path().join("specialisation").join(spec)),
         };
 
-        // just do nothing for None case (fresh installs)
+        // Just do nothing for None case (fresh installs)
         if let Some(generation) = prev_generation {
-            Command::new("nvd")
-                .arg("diff")
-                .arg(generation)
-                .arg(target_profile.get_path())
-                .message("Comparing changes")
-                .run()?;
+            platform::compare_configurations(
+                generation.to_str().unwrap_or(""),
+                target_profile.get_path(),
+                false,
+                "Comparing changes",
+            )?;
         }
 
         if self.common.dry || matches!(variant, Build) {

--- a/src/home.rs
+++ b/src/home.rs
@@ -10,6 +10,12 @@ use crate::update::update;
 use crate::util::platform;
 
 impl interface::HomeArgs {
+    /// Entry point for processing home-manager commands
+    ///
+    /// Handles the different subcommands for home-manager configurations:
+    /// - Switch: Builds and activates the configuration
+    /// - Build: Only builds the configuration
+    /// - Repl: Opens a REPL for exploring the configuration
     pub fn run(self) -> Result<()> {
         use HomeRebuildVariant::{Build, Switch};
         match self.subcommand {
@@ -25,6 +31,11 @@ impl interface::HomeArgs {
     }
 }
 
+/// Variants of the home-manager rebuild operation
+///
+/// Represents different actions that can be taken with a home-manager configuration:
+/// - Build: Only build the configuration without activating it
+/// - Switch: Build and activate the configuration
 #[derive(Debug)]
 enum HomeRebuildVariant {
     Build,
@@ -32,6 +43,18 @@ enum HomeRebuildVariant {
 }
 
 impl HomeRebuildArgs {
+    /// Performs the rebuild operation for home-manager configurations
+    ///
+    /// This function handles building and potentially activating home-manager configurations.
+    /// The workflow:
+    /// 1. Updates the flake if requested
+    /// 2. Creates a temporary output path
+    /// 3. Builds the configuration with proper specialisation handling
+    /// 4. Compares with the previous generation if it exists
+    /// 5. Activates the configuration if needed
+    ///
+    /// Home Manager has its own specialisation mechanism which this function handles
+    /// by looking in ~/.local/share/home-manager/specialisation.
     fn rebuild(self, variant: HomeRebuildVariant) -> Result<()> {
         use HomeRebuildVariant::Build;
 
@@ -138,6 +161,11 @@ impl HomeRebuildArgs {
 }
 
 impl HomeReplArgs {
+    /// Opens a Nix REPL for exploring home-manager configurations
+    ///
+    /// Provides an interactive environment to explore and evaluate
+    /// components of a home-manager configuration. This is useful for
+    /// debugging or exploring available options.
     fn run(self) -> Result<()> {
         // Use NH_HOME_FLAKE if available, otherwise use the provided installable
         let installable = platform::resolve_env_installable("NH_HOME_FLAKE", self.installable);

--- a/src/installable.rs
+++ b/src/installable.rs
@@ -4,7 +4,6 @@ use std::{env, fs};
 use clap::error::ErrorKind;
 use clap::{Arg, ArgAction, Args, FromArgMatches};
 use color_eyre::owo_colors::OwoColorize;
-
 // Reference: https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix
 
 #[derive(Debug, Clone)]
@@ -24,6 +23,15 @@ pub enum Installable {
         expression: String,
         attribute: Vec<String>,
     },
+}
+
+impl Default for Installable {
+    fn default() -> Self {
+        Self::Flake {
+            reference: ".".to_string(),
+            attribute: Vec::new(),
+        }
+    }
 }
 
 impl FromArgMatches for Installable {

--- a/src/json.rs
+++ b/src/json.rs
@@ -28,6 +28,7 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
+#[allow(dead_code)]
 impl<'v> Value<'v> {
     pub const fn new(value: &'v serde_json::Value) -> Self {
         Self {

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -318,7 +318,9 @@ impl OsRollbackArgs {
         let mut _rollback_profile = false;
 
         // Get the final profile path with specialisation if any
-        let final_profile = platform::get_target_profile(&generation_link, &target_specialisation);
+        let target_specialisation_option = target_specialisation;
+        let final_profile =
+            platform::get_target_profile(&generation_link, &target_specialisation_option);
 
         // Activate the configuration
         info!("Activating...");

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -36,19 +36,19 @@ impl interface::OsArgs {
     /// - `BuildVm`: Builds a `NixOS` VM image
     pub fn run(self) -> Result<()> {
         use OsRebuildVariant::{Boot, Build, Switch, Test};
-        // Always resolve installable from env var at the top
-        let resolved_installable = platform::resolve_env_installable(
-            "NH_OS_FLAKE",
-            match &self.subcommand {
-                OsSubcommand::Boot(args) => args.common.installable.clone(),
-                OsSubcommand::Test(args) => args.common.installable.clone(),
-                OsSubcommand::Switch(args) => args.common.installable.clone(),
-                OsSubcommand::Build(args) => args.common.installable.clone(),
-                OsSubcommand::BuildVm(args) => args.common.common.installable.clone(),
-                OsSubcommand::Repl(args) => args.installable.clone(),
-                _ => Installable::default(), // fallback for Info/Rollback, not used
-            },
-        );
+        // Always resolve installable from env var at the top, or use the provided one
+        let fallback_installable = match &self.subcommand {
+            OsSubcommand::Boot(args) => args.common.installable.clone(),
+            OsSubcommand::Test(args) => args.common.installable.clone(),
+            OsSubcommand::Switch(args) => args.common.installable.clone(),
+            OsSubcommand::Build(args) => args.common.installable.clone(),
+            OsSubcommand::BuildVm(args) => args.common.common.installable.clone(),
+            OsSubcommand::Repl(args) => args.installable.clone(),
+            _ => Installable::default(), // fallback for Info/Rollback, not used
+        };
+
+        let resolved_installable =
+            platform::resolve_env_installable("NH_OS_FLAKE").unwrap_or(fallback_installable);
         match self.subcommand {
             OsSubcommand::Boot(args) => {
                 args.rebuild_with_installable(Boot, None, resolved_installable)

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,9 @@ use tempfile::TempDir;
 
 use crate::commands::Command;
 
+// Platform-specific functionality abstracted into shared components
+pub mod platform;
+
 /// Retrieves the installed Nix version as a string.
 ///
 /// This function executes the `nix --version` command, parses the output to

--- a/src/util/platform.rs
+++ b/src/util/platform.rs
@@ -10,9 +10,12 @@ use tracing::{debug, info, warn};
 use crate::commands;
 use crate::installable::Installable;
 
-/// Resolves an Installable from an environment variable, or falls back to the provided one.
-pub fn resolve_env_installable(var: &str, fallback: Installable) -> Installable {
-    if let Ok(val) = env::var(var) {
+/// Resolves an Installable from an environment variable.
+///
+/// Returns `Some(Installable)` if the environment variable is set and can be parsed,
+/// or `None` if the environment variable is not set.
+pub fn resolve_env_installable(var: &str) -> Option<Installable> {
+    env::var(var).ok().map(|val| {
         let mut elems = val.splitn(2, '#');
         let reference = elems.next().unwrap().to_owned();
         let attribute = elems
@@ -23,9 +26,7 @@ pub fn resolve_env_installable(var: &str, fallback: Installable) -> Installable 
             reference,
             attribute,
         }
-    } else {
-        fallback
-    }
+    })
 }
 
 /// Extends an Installable with the appropriate attribute path for a platform.

--- a/src/util/platform.rs
+++ b/src/util/platform.rs
@@ -337,7 +337,37 @@ pub fn process_specialisation(
 }
 
 /// Execute common actions for a rebuild operation across platforms
-/// This unifies the core workflow that was previously duplicated across platforms
+///
+/// This function handles the core workflow for building and managing system
+/// configurations across different platforms (`NixOS`, Darwin, Home Manager).
+/// It unifies what would otherwise be duplicated across platform-specific modules.
+///
+/// The function takes care of:
+/// 1. Properly configuring the attribute path based on platform type
+/// 2. Building the configuration
+/// 3. Handling specialisations where applicable
+/// 4. Comparing the new configuration with the current one
+///
+/// # Arguments
+///
+/// * `installable` - The Nix installable representing the configuration
+/// * `config_type` - The configuration type (e.g., "nixosConfigurations", "darwinConfigurations")
+/// * `extra_path` - Additional path elements for the attribute path
+/// * `config_name` - Optional hostname or configuration name
+/// * `out_path` - Output path for the build result
+/// * `extra_args` - Additional arguments to pass to the build command
+/// * `builder` - Optional remote builder to use
+/// * `message` - Message to display during the build process
+/// * `no_nom` - Whether to disable nix-output-monitor
+/// * `specialisation_path` - Path to read specialisations from
+/// * `no_specialisation` - Whether to ignore specialisations
+/// * `specialisation` - Optional explicit specialisation to use
+/// * `current_profile` - Path to the current system profile for comparison
+/// * `skip_compare` - Whether to skip comparing the new and current configuration
+///
+/// # Returns
+///
+/// The path to the built configuration, which can be used for activation
 pub fn handle_rebuild_workflow(
     installable: Installable,
     config_type: &str,
@@ -379,7 +409,7 @@ pub fn handle_rebuild_workflow(
         {
             // All darwin configurations expose their outputs under system.build
             let toplevel_path = ["config", "system", "build"];
-            attribute.extend(toplevel_path.iter().map(|s| s.to_string()));
+            attribute.extend(toplevel_path.iter().map(|s| (*s).to_string()));
 
             // Add the final component (usually "toplevel")
             if !extra_path.is_empty() {

--- a/src/util/platform.rs
+++ b/src/util/platform.rs
@@ -1,0 +1,447 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::bail;
+use color_eyre::Result;
+use tracing::{debug, info, warn};
+
+use crate::commands;
+use crate::installable::Installable;
+
+/// Resolves an Installable from an environment variable, or falls back to the provided one.
+pub fn resolve_env_installable(var: &str, fallback: Installable) -> Installable {
+    if let Ok(val) = env::var(var) {
+        let mut elems = val.splitn(2, '#');
+        let reference = elems.next().unwrap().to_owned();
+        let attribute = elems
+            .next()
+            .map(crate::installable::parse_attribute)
+            .unwrap_or_default();
+        Installable::Flake {
+            reference,
+            attribute,
+        }
+    } else {
+        fallback
+    }
+}
+
+/// Extends an Installable with the appropriate attribute path for a platform.
+///
+/// - `config_type`: e.g. "homeConfigurations", "nixosConfigurations", "darwinConfigurations"
+/// - `extra_path`: e.g. ["config", "home", "activationPackage"]
+/// - `config_name`: Optional configuration name (e.g. username@hostname)
+/// - `push_drv`: Whether to push the drv path (platform-specific)
+/// - `extra_args`: Extra args for nix eval (for config detection)
+pub fn extend_installable_for_platform(
+    mut installable: Installable,
+    config_type: &str,
+    extra_path: &[&str],
+    config_name: Option<String>,
+    push_drv: bool,
+    extra_args: &[OsString],
+) -> Result<Installable> {
+    use tracing::debug;
+
+    use crate::commands;
+    use crate::util::get_hostname;
+    match &mut installable {
+        Installable::Flake {
+            reference,
+            attribute,
+        } => {
+            if !attribute.is_empty() {
+                debug!(
+                    "Using explicit attribute path from installable: {:?}",
+                    attribute
+                );
+                return Ok(installable);
+            }
+            attribute.push(config_type.to_string());
+            let flake_reference = reference.clone();
+            let mut found_config = false;
+            if let Some(config_name) = config_name {
+                let func = format!(r#"x: x ? "{config_name}""#);
+                let check_res = commands::Command::new("nix")
+                    .arg("eval")
+                    .args(extra_args)
+                    .arg("--apply")
+                    .arg(&func)
+                    .args(
+                        (Installable::Flake {
+                            reference: flake_reference.clone(),
+                            attribute: attribute.clone(),
+                        })
+                        .to_args(),
+                    )
+                    .run_capture();
+                if let Ok(res) = check_res {
+                    if res.map(|s| s.trim().to_owned()).as_deref() == Some("true") {
+                        debug!("Using explicit configuration from flag: {}", config_name);
+                        attribute.push(config_name);
+                        if push_drv {
+                            attribute.extend(extra_path.iter().map(|s| (*s).to_string()));
+                        }
+                        found_config = true;
+                    }
+                }
+                if !found_config {
+                    return Err(color_eyre::eyre::eyre!(
+                        "Explicitly specified configuration not found in flake."
+                    ));
+                }
+            }
+            if !found_config {
+                // Try to auto-detect the configuration if none was specified
+                let username = std::env::var("USER").unwrap_or_else(|_| "user".to_string());
+                let hostname = get_hostname().unwrap_or_else(|_| "host".to_string());
+                for attr_name in [format!("{username}@{hostname}"), username] {
+                    let func = format!(r#"x: x ? "{attr_name}""#);
+                    let check_res = commands::Command::new("nix")
+                        .arg("eval")
+                        .args(extra_args)
+                        .arg("--apply")
+                        .arg(&func)
+                        .args(
+                            (Installable::Flake {
+                                reference: flake_reference.clone(),
+                                attribute: attribute.clone(),
+                            })
+                            .to_args(),
+                        )
+                        .run_capture();
+                    if let Ok(res) = check_res {
+                        if res.map(|s| s.trim().to_owned()).as_deref() == Some("true") {
+                            debug!("Using automatically detected configuration: {}", attr_name);
+                            attribute.push(attr_name);
+                            if push_drv {
+                                attribute.extend(extra_path.iter().map(|s| (*s).to_string()));
+                            }
+                            found_config = true;
+                            break;
+                        }
+                    }
+                }
+                if !found_config {
+                    return Err(color_eyre::eyre::eyre!(
+                        "Couldn't find configuration automatically in flake."
+                    ));
+                }
+            }
+        }
+        Installable::File { attribute, .. } | Installable::Expression { attribute, .. } => {
+            if push_drv {
+                attribute.extend(extra_path.iter().map(|s| (*s).to_string()));
+            }
+        }
+        Installable::Store { .. } => {
+            // Nothing to do for store paths
+        }
+    }
+    Ok(installable)
+}
+
+/// Handles common specialisation logic for all platforms
+pub fn handle_specialisation(
+    specialisation_path: &str,
+    no_specialisation: bool,
+    explicit_specialisation: Option<String>,
+) -> Option<String> {
+    if no_specialisation {
+        None
+    } else {
+        let current_specialisation = std::fs::read_to_string(specialisation_path).ok();
+        explicit_specialisation.or(current_specialisation)
+    }
+}
+
+/// Checks if the user wants to proceed with applying the configuration
+pub fn confirm_action(ask: bool, dry: bool) -> Result<bool> {
+    use tracing::{info, warn};
+
+    if dry {
+        if ask {
+            warn!("--ask has no effect as dry run was requested");
+        }
+        return Ok(false);
+    }
+
+    if ask {
+        info!("Apply the config?");
+        let confirmation = dialoguer::Confirm::new().default(false).interact()?;
+
+        if !confirmation {
+            bail!("User rejected the new config");
+        }
+    }
+
+    Ok(true)
+}
+
+/// Common function to ensure we're not running as root
+pub fn check_not_root(bypass_root_check: bool) -> Result<bool> {
+    use tracing::warn;
+
+    if bypass_root_check {
+        warn!("Bypassing root check, now running nix as root");
+        return Ok(false);
+    }
+
+    if nix::unistd::Uid::effective().is_root() {
+        // Protect users from themselves
+        bail!("Don't run nh os as root. I will call sudo internally as needed");
+    }
+
+    Ok(true)
+}
+
+/// Creates a temporary output path for build results
+pub fn create_output_path(
+    out_link: Option<impl AsRef<std::path::Path>>,
+    prefix: &str,
+) -> Result<Box<dyn crate::util::MaybeTempPath>> {
+    let out_path: Box<dyn crate::util::MaybeTempPath> = match out_link {
+        Some(ref p) => Box::new(std::path::PathBuf::from(p.as_ref())),
+        None => Box::new({
+            let dir = tempfile::Builder::new().prefix(prefix).tempdir()?;
+            (dir.as_ref().join("result"), dir)
+        }),
+    };
+
+    Ok(out_path)
+}
+
+/// Compare configurations using nvd diff
+pub fn compare_configurations(
+    current_profile: &str,
+    target_profile: &std::path::Path,
+    skip_compare: bool,
+    message: &str,
+) -> Result<()> {
+    if skip_compare {
+        debug!("Skipping configuration comparison");
+        return Ok(());
+    }
+
+    commands::Command::new("nvd")
+        .arg("diff")
+        .arg(current_profile)
+        .arg(target_profile)
+        .message(message)
+        .run()?;
+
+    Ok(())
+}
+
+/// Build a configuration using the nix build command
+pub fn build_configuration(
+    installable: Installable,
+    out_path: &dyn crate::util::MaybeTempPath,
+    extra_args: &[impl AsRef<std::ffi::OsStr>],
+    builder: Option<String>,
+    message: &str,
+    no_nom: bool,
+) -> Result<()> {
+    commands::Build::new(installable)
+        .extra_arg("--out-link")
+        .extra_arg(out_path.get_path())
+        .extra_args(extra_args)
+        .builder(builder)
+        .message(message)
+        .nom(!no_nom)
+        .run()?;
+
+    Ok(())
+}
+
+/// Determine the target profile path considering specialisation
+pub fn get_target_profile(
+    out_path: &dyn crate::util::MaybeTempPath,
+    target_specialisation: &Option<String>,
+) -> PathBuf {
+    match target_specialisation {
+        None => out_path.get_path().to_owned(),
+        Some(spec) => out_path.get_path().join("specialisation").join(spec),
+    }
+}
+
+/// Common logic for handling REPL for different platforms
+pub fn run_repl(
+    installable: Installable,
+    config_type: &str,
+    extra_path: &[&str],
+    config_name: Option<String>,
+    extra_args: &[String],
+) -> Result<()> {
+    // Store paths don't work with REPL
+    if let Installable::Store { .. } = installable {
+        bail!("Nix doesn't support nix store installables with repl.");
+    }
+
+    let installable = extend_installable_for_platform(
+        installable,
+        config_type,
+        extra_path,
+        config_name,
+        false,
+        &[],
+    )?;
+
+    debug!("Running nix repl with installable: {:?}", installable);
+
+    // Note: Using stdlib Command directly is necessary for interactive REPL
+    use std::process::{Command as StdCommand, Stdio};
+
+    let mut command = StdCommand::new("nix");
+    command.arg("repl");
+
+    // Add installable arguments
+    for arg in installable.to_args() {
+        command.arg(arg);
+    }
+
+    // Add any extra arguments
+    for arg in extra_args {
+        command.arg(arg);
+    }
+
+    // Configure for interactive use
+    command
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    // Execute and wait for completion
+    let status = command.status()?;
+
+    if !status.success() {
+        bail!("nix repl exited with non-zero status: {}", status);
+    }
+
+    Ok(())
+}
+
+/// Process the target specialisation based on common patterns
+pub fn process_specialisation(
+    no_specialisation: bool,
+    specialisation: Option<String>,
+    specialisation_path: &str,
+) -> Result<Option<String>> {
+    let target_specialisation =
+        handle_specialisation(specialisation_path, no_specialisation, specialisation);
+
+    debug!("target_specialisation: {target_specialisation:?}");
+
+    Ok(target_specialisation)
+}
+
+/// Execute common actions for a rebuild operation across platforms
+/// This unifies the core workflow that was previously duplicated across platforms
+pub fn handle_rebuild_workflow(
+    installable: Installable,
+    config_type: &str,
+    extra_path: &[&str],
+    config_name: Option<String>,
+    out_path: &dyn crate::util::MaybeTempPath,
+    extra_args: &[impl AsRef<std::ffi::OsStr>],
+    builder: Option<String>,
+    message: &str,
+    no_nom: bool,
+    specialisation_path: &str,
+    no_specialisation: bool,
+    specialisation: Option<String>,
+    current_profile: &str,
+    skip_compare: bool,
+) -> Result<PathBuf> {
+    // Configure the installable with platform-specific attributes
+    let configured_installable = extend_installable_for_platform(
+        installable,
+        config_type,
+        extra_path,
+        config_name,
+        true,
+        &extra_args
+            .iter()
+            .map(std::convert::AsRef::as_ref)
+            .map(std::convert::Into::into)
+            .collect::<Vec<_>>(),
+    )?;
+
+    // Build the configuration
+    build_configuration(
+        configured_installable,
+        out_path,
+        extra_args,
+        builder,
+        message,
+        no_nom,
+    )?;
+
+    // Process any specialisations
+    let target_specialisation =
+        process_specialisation(no_specialisation, specialisation, specialisation_path)?;
+
+    // Get target profile path
+    let target_profile = get_target_profile(out_path, &target_specialisation);
+
+    // Compare configurations if applicable
+    if !skip_compare {
+        compare_configurations(current_profile, &target_profile, false, "Comparing changes")?;
+    }
+
+    Ok(target_profile)
+}
+
+/// Determine proper hostname based on provided or automatically detected
+pub fn get_target_hostname(
+    explicit_hostname: Option<String>,
+    skip_if_mismatch: bool,
+) -> Result<(String, bool)> {
+    let system_hostname = match crate::util::get_hostname() {
+        Ok(hostname) => {
+            debug!("Auto-detected hostname: {}", hostname);
+            Some(hostname)
+        }
+        Err(err) => {
+            warn!("Failed to detect hostname: {}", err);
+            None
+        }
+    };
+
+    let target_hostname = match explicit_hostname {
+        Some(hostname) => hostname,
+        None => match system_hostname.clone() {
+            Some(hostname) => hostname,
+            None => bail!("Unable to fetch hostname automatically, and no hostname supplied. Please specify explicitly.")
+        }
+    };
+
+    // Skip comparison when system hostname != target hostname if requested
+    let hostname_mismatch = skip_if_mismatch
+        && system_hostname.is_some()
+        && system_hostname.unwrap() != target_hostname;
+
+    Ok((target_hostname, hostname_mismatch))
+}
+
+/// Common function to activate configurations in `NixOS`
+pub fn activate_nixos_configuration(
+    target_profile: &Path,
+    variant: &str,
+    target_host: Option<String>,
+    elevate: bool,
+    message: &str,
+) -> Result<()> {
+    let switch_to_configuration = target_profile.join("bin").join("switch-to-configuration");
+    let switch_to_configuration = switch_to_configuration.canonicalize().map_err(|e| {
+        color_eyre::eyre::eyre!("Failed to canonicalize switch-to-configuration path: {}", e)
+    })?;
+
+    commands::Command::new(switch_to_configuration)
+        .arg(variant)
+        .ssh(target_host)
+        .message(message)
+        .elevate(elevate)
+        .run()
+}


### PR DESCRIPTION
Welcome back funny PR.

Something something consolidates duplicate platform logic something. Hopefully not a breaking change but I'm pushing this while *incredibly* sick and will go back to bed right after.