### PR TITLE
fix: preserve environment variables after self_elevate()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn self_elevate() -> ! {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = std::process::Command::new("sudo");
+    cmd.arg("--preserve-env");
 
     // use NH_SUDO_ASKPASS program for sudo if present
     let askpass = std::env::var("NH_SUDO_ASKPASS");


### PR DESCRIPTION
Closes #289

Some environment variables such as `NH_NO_CHECKS` modify the behaviour of commands that require elevated privileges such as `nh clean all`. This fix allows all environment variables to be preserved after the call to `self_elevate()`.