### PR TITLE
Allow switching between specialisations.

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -99,15 +99,13 @@ impl HomeRebuildArgs {
 
         debug!(?prev_generation);
 
-        let spec_location =
-            PathBuf::from(std::env::var("HOME")?).join(".local/share/home-manager/specialisation");
-
-        let current_specialisation = std::fs::read_to_string(spec_location.to_str().unwrap()).ok();
-
         let target_specialisation = if self.no_specialisation {
             None
         } else {
-            current_specialisation.or(self.specialisation)
+            let spec_location = PathBuf::from(std::env::var("HOME")?)
+                .join(".local/share/home-manager/specialisation");
+            self.specialisation
+                .or(std::fs::read_to_string(spec_location).ok())
         };
 
         debug!("target_specialisation: {target_specialisation:?}");

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -153,12 +153,11 @@ impl OsRebuildArgs {
             .nom(!self.common.no_nom)
             .run()?;
 
-        let current_specialisation = std::fs::read_to_string(SPEC_LOCATION).ok();
-
         let target_specialisation = if self.no_specialisation {
             None
         } else {
-            current_specialisation.or_else(|| self.specialisation.clone())
+            self.specialisation
+                .or(std::fs::read_to_string(SPEC_LOCATION).ok())
         };
 
         debug!("target_specialisation: {target_specialisation:?}");


### PR DESCRIPTION
Prefer switching to specialisation provided as `--specialisation` argument over current specialisation.

---

Currently, assuming a config like in the README

```nix
{config, pkgs, ...}: {
  specialisation."foo".configuration = {
    environment.etc."specialisation".text = "foo";
    # ..rest of config
  };

  specialisation."bar".configuration = {
    environment.etc."specialisation".text = "bar";
    # ..rest of config
  };
}
```

we have this - in my optinion - unexpected behaviour:

```sh
nh os switch -s foo # switch to foo
nh os switch -s bar # switch back to no-specialisation
```

---

After these changes

```sh
nh os switch -s bar
```

and 

```sh
nh home switch -s bar
```

switch to the bar specialisation regardless of the current specialisation.
