### PR TITLE
fix cargo clippy command in fix.sh

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -5,8 +5,7 @@ echo "Running 'cargo fix' on the codebase"
 cargo fix --allow-dirty
 
 echo "Running clippy linter and applying available fixes"
-cargo clippy --fix --allow-dirty \
-	-W clippy::pedantic \
+cargo clippy --fix --allow-dirty --\
 	-W clippy::pedantic \
 	-W clippy::correctness \
 	-W clippy::suspicious


### PR DESCRIPTION
Running `./fix.sh` errors with

```sh
+ echo 'Running clippy linter and applying available fixes'
Running clippy linter and applying available fixes
+ cargo clippy --fix --allow-dirty -W clippy::pedantic -W clippy::pedantic -W clippy::correctness -W clippy::suspicious
error: unexpected argument '-W' found
```

This fixes it and removes a duplicate line.