### PR TITLE
Disable check for repl-flake on lix>=2.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Nh now checks if the current Nix implementation has necessary experimental
   features enabled. In mainline Nix (CppNix, etc.) we check for `nix-command`
   and `flakes` being set. In Lix, we also use `repl-flake` as it is still
-  provided as an experimental feature.
+  provided as an experimental feature in versions below 2.93.0.
 
 - Nh will now check if you are using the latest stable, or "recommended,"
   version of Nix (or Lix.) This check has been placed to make it clear we do not

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -73,9 +73,13 @@ pub fn check_nix_features() -> Result<()> {
 
     let mut required_features = vec!["nix-command", "flakes"];
 
-    // Lix still uses repl-flake, which is removed in the latest version of Nix.
+    // Lix up until 2.93.0 uses repl-flake, which is removed in the latest version of Nix.
     if util::is_lix()? {
-        required_features.push("repl-flake");
+        let repl_flake_removed_in_lix_version = Version::parse("2.93.0")?;
+        let current_lix_version = Version::parse(&util::get_nix_version()?)?;
+        if current_lix_version < repl_flake_removed_in_lix_version {
+            required_features.push("repl-flake");
+        }
     }
 
     tracing::debug!("Required Nix features: {}", required_features.join(", "));


### PR DESCRIPTION
As the latest lix release has removed the repl-flake feature, we can't demand it on that version anymore.

This fixes #278. (I tested by overriding nixpkgs' nh package with the patch from this PR.)