### PR TITLE
treewide: fix nvd diffs and internal cleanup

### DIFF
--- a/src/generations.rs
+++ b/src/generations.rs
@@ -43,7 +43,7 @@ pub fn from_dir(generation_dir: &Path) -> Option<u64> {
         })
 }
 
-pub fn describe(generation_dir: &Path, _current_profile: &Path) -> Option<GenerationInfo> {
+pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
     let generation_number = from_dir(generation_dir)?;
 
     // Get metadata once and reuse for both date and existence checks

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -43,7 +43,7 @@ pub fn from_dir(generation_dir: &Path) -> Option<u64> {
         })
 }
 
-pub fn describe(generation_dir: &Path, current_profile: &Path) -> Option<GenerationInfo> {
+pub fn describe(generation_dir: &Path, _current_profile: &Path) -> Option<GenerationInfo> {
     let generation_number = from_dir(generation_dir)?;
 
     // Get metadata once and reuse for both date and existence checks

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -459,7 +459,7 @@ fn find_previous_generation() -> Result<generations::GenerationInfo> {
             if let Some(filename) = path.file_name() {
                 if let Some(name) = filename.to_str() {
                     if name.starts_with("system-") && name.ends_with("-link") {
-                        return generations::describe(&path, &profile_path);
+                        return generations::describe(&path);
                     }
                 }
             }
@@ -505,7 +505,7 @@ fn find_generation_by_number(number: u64) -> Result<generations::GenerationInfo>
             if let Some(filename) = path.file_name() {
                 if let Some(name) = filename.to_str() {
                     if name.starts_with("system-") && name.ends_with("-link") {
-                        return generations::describe(&path, &profile_path);
+                        return generations::describe(&path);
                     }
                 }
             }
@@ -530,11 +530,7 @@ fn get_current_generation_number() -> Result<u64> {
             .parent()
             .unwrap_or(Path::new("/nix/var/nix/profiles")),
     )?
-    .filter_map(|entry| {
-        entry
-            .ok()
-            .and_then(|e| generations::describe(&e.path(), &profile_path))
-    })
+    .filter_map(|entry| entry.ok().and_then(|e| generations::describe(&e.path())))
     .collect();
 
     let current_gen = generations
@@ -679,7 +675,7 @@ impl OsGenerationsArgs {
 
         let descriptions: Vec<generations::GenerationInfo> = generations
             .iter()
-            .filter_map(|gen_dir| generations::describe(gen_dir, &profile))
+            .filter_map(|gen_dir| generations::describe(gen_dir))
             .collect();
 
         generations::print_info(descriptions);

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -200,26 +200,18 @@ impl OsRebuildArgs {
             && self.target_host.is_none()
             && system_hostname.map_or(true, |h| h == target_hostname)
         {
-            // Verify the target_profile path exists before attempting to use it
-            if matches!(target_profile.try_exists(), Ok(true)) {
-                debug!(
-                    "Comparing with target profile: {}",
-                    target_profile.display()
-                );
+            debug!(
+                "Comparing with target profile: {}",
+                target_profile.display()
+            );
 
-                Command::new("nvd")
-                    .arg("diff")
-                    .arg(CURRENT_PROFILE)
-                    .arg(&target_profile)
-                    .message("Comparing changes")
-                    .show_output(true)
-                    .run()?;
-            } else {
-                warn!(
-                    "Cannot compare changes - target profile path does not exist: {}",
-                    target_profile.display()
-                );
-            }
+            Command::new("nvd")
+                .arg("diff")
+                .arg(CURRENT_PROFILE)
+                .arg(&target_profile)
+                .message("Comparing changes")
+                .show_output(true)
+                .run()?;
         } else {
             debug!("Not running nvd as the target hostname is different from the system hostname.");
         }

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -56,6 +56,7 @@ enum OsRebuildVariant {
 impl OsBuildVmArgs {
     fn build_vm(self) -> Result<()> {
         let final_attr = get_final_attr(true, self.with_bootloader);
+        debug!("Building VM with attribute: {}", final_attr);
         self.common
             .rebuild(OsRebuildVariant::BuildVm, Some(final_attr))
     }
@@ -97,7 +98,16 @@ impl OsRebuildArgs {
             Some(h) => h.to_owned(),
             None => match &system_hostname {
                 Some(hostname) => {
-                    tracing::warn!("Guessing system is {hostname} for a VM image. If this isn't intended, use --hostname to change.");
+                    // Only show the warning if we're explicitly building a VM
+                    // by directly calling build_vm(), not when the BuildVm variant
+                    // is used internally via other code paths
+                    if matches!(variant, OsRebuildVariant::BuildVm)
+                        && final_attr
+                            .as_deref()
+                            .map_or(false, |attr| attr == "vm" || attr == "vmWithBootLoader")
+                    {
+                        tracing::warn!("Guessing system is {hostname} for a VM image. If this isn't intended, use --hostname to change.");
+                    }
                     hostname.clone()
                 }
                 None => return Err(eyre!("Unable to fetch hostname, and no hostname supplied.")),
@@ -143,7 +153,6 @@ impl OsRebuildArgs {
             BuildVm => "Building NixOS VM image",
             _ => "Building NixOS configuration",
         };
-
         commands::Build::new(toplevel)
             .extra_arg("--out-link")
             .extra_arg(out_path.get_path())
@@ -168,20 +177,49 @@ impl OsRebuildArgs {
             Some(spec) => out_path.get_path().join("specialisation").join(spec),
         };
 
-        debug!("exists: {}", target_profile.exists());
+        debug!("Output path: {}", out_path.get_path().display());
+        debug!("Target profile path: {}", target_profile.display());
+        debug!("Target profile exists: {}", target_profile.exists());
 
-        target_profile.try_exists().context("Doesn't exist")?;
+        // Take a strong reference to out_path to prevent premature dropping
+        // This prevents the tempdir from being dropped early, which would cause nvd diff to fail
+        #[allow(unused_variables)]
+        let keep_alive = out_path.get_path().to_owned();
+
+        if !target_profile
+            .try_exists()
+            .context("Failed to check if target profile exists")?
+        {
+            return Err(eyre!(
+                "Target profile path does not exist: {}",
+                target_profile.display()
+            ));
+        }
 
         if self.build_host.is_none()
             && self.target_host.is_none()
             && system_hostname.map_or(true, |h| h == target_hostname)
         {
-            Command::new("nvd")
-                .arg("diff")
-                .arg(CURRENT_PROFILE)
-                .arg(&target_profile)
-                .message("Comparing changes")
-                .run()?;
+            // Verify the target_profile path exists before attempting to use it
+            if matches!(target_profile.try_exists(), Ok(true)) {
+                debug!(
+                    "Comparing with target profile: {}",
+                    target_profile.display()
+                );
+
+                Command::new("nvd")
+                    .arg("diff")
+                    .arg(CURRENT_PROFILE)
+                    .arg(&target_profile)
+                    .message("Comparing changes")
+                    .show_output(true)
+                    .run()?;
+            } else {
+                warn!(
+                    "Cannot compare changes - target profile path does not exist: {}",
+                    target_profile.display()
+                );
+            }
         } else {
             debug!("Not running nvd as the target hostname is different from the system hostname.");
         }
@@ -253,8 +291,12 @@ impl OsRebuildArgs {
                 .run()?;
         }
 
-        // Make sure out_path is not accidentally dropped
+        // Make sure out_path is not acidentally dropped
         // https://docs.rs/tempfile/3.12.0/tempfile/index.html#early-drop-pitfall
+        debug!(
+            "Completed operation with output path: {:?}",
+            out_path.get_path()
+        );
         drop(out_path);
 
         Ok(())
@@ -305,6 +347,7 @@ impl OsRollbackArgs {
             .arg(CURRENT_PROFILE)
             .arg(&generation_link)
             .message("Comparing changes")
+            .show_output(true)
             .run()?;
 
         if self.dry {
@@ -345,9 +388,6 @@ impl OsRollbackArgs {
             .message("Setting system profile")
             .run()?;
 
-        // Set up rollback protection flag
-        let mut rollback_profile = false;
-
         // Determine the correct profile to use with specialisations
         let final_profile = match &target_specialisation {
             None => generation_link,
@@ -383,10 +423,8 @@ impl OsRollbackArgs {
                 );
             }
             Err(e) => {
-                rollback_profile = true;
-
                 // If activation fails, rollback the profile
-                if rollback_profile && current_gen_number > 0 {
+                if current_gen_number > 0 {
                     let current_gen_link =
                         profile_dir.join(format!("system-{current_gen_number}-link"));
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -181,10 +181,8 @@ impl OsRebuildArgs {
         debug!("Target profile path: {}", target_profile.display());
         debug!("Target profile exists: {}", target_profile.exists());
 
-        // Take a strong reference to out_path to prevent premature dropping
-        // This prevents the tempdir from being dropped early, which would cause nvd diff to fail
-        #[allow(unused_variables)]
-        let keep_alive = out_path.get_path().to_owned();
+        // Note: out_path itself is kept alive until the end of this function,
+        // which prevents the tempdir (if any) from being dropped early
 
         if !target_profile
             .try_exists()


### PR DESCRIPTION
This'll create some merge conflicts, but I'd like to get this fixed before I take an extended break. Fixes nvd diffs and supresses a redundant argument that would occur after #208. Also improves debug logging for references that we need to keep track of. Should help track down issues such as this one easier in the future.

CC @khaneliman for Darwin testing, seems to be working as intended on NixOS- testing for Home Manager would also be great.