### PR TITLE
{package,shell}: remove darwin stubs

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,10 +1,8 @@
 {
-  stdenv,
   lib,
   rustPlatform,
   installShellFiles,
   makeBinaryWrapper,
-  darwin,
   nvd,
   use-nom ? true,
   nix-output-monitor ? null,
@@ -36,8 +34,6 @@ rustPlatform.buildRustPackage {
     installShellFiles
     makeBinaryWrapper
   ];
-
-  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   postInstall = ''
     mkdir completions

--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,6 @@ mkShell {
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.SystemConfiguration
     libiconv
   ];
 


### PR DESCRIPTION
Deprecated, in stdenv and doesn't need to be there. Throws warning.