### PR TITLE
build and build-vm now default to output in ./result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # NH Changelog
 
+## Unreleased
+
+- `nh os build` and `nh os build-vm` now default to placing the output at
+  `./result` instead of a temp directory.
+
 ## 4.1.0
 
 ### Added

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -116,10 +116,13 @@ impl OsRebuildArgs {
 
         let out_path: Box<dyn crate::util::MaybeTempPath> = match self.common.out_link {
             Some(ref p) => Box::new(p.clone()),
-            None => Box::new({
-                let dir = tempfile::Builder::new().prefix("nh-os").tempdir()?;
-                (dir.as_ref().join("result"), dir)
-            }),
+            None => match variant {
+                BuildVm | Build => Box::new(PathBuf::from("result")),
+                _ => Box::new({
+                    let dir = tempfile::Builder::new().prefix("nh-os").tempdir()?;
+                    (dir.as_ref().join("result"), dir)
+                }),
+            },
         };
 
         debug!(?out_path);


### PR DESCRIPTION
This fixes #297.
