### PR TITLE
meta: switch to Nixpkgs 25.05; bump Cargo edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nh"
 version = "4.1.0"
-edition = "2021"
+edition = "2024"
 license = "EUPL-1.2"
 repository = "https://github.com/nix-community/nh"
 description = "Yet Another Nix Helper"

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746557022,
-        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
+        "lastModified": 1748302896,
+        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
+        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
   };
 
   outputs =

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, env};
 
-use color_eyre::{eyre, Result};
+use color_eyre::{Result, eyre};
 use semver::Version;
 use tracing::warn;
 
@@ -51,9 +51,7 @@ pub fn check_nix_version() -> Result<()> {
             let binary_name = if is_lix_binary { "Lix" } else { "Nix" };
             warn!(
                 "Warning: {} version {} is older than the recommended minimum version {}. You may encounter issues.",
-                binary_name,
-                version,
-                min_version
+                binary_name, version, min_version
             );
             Ok(())
         }
@@ -124,7 +122,9 @@ pub fn setup_environment() -> Result<bool> {
     if let Ok(f) = std::env::var("FLAKE") {
         // Set NH_FLAKE if it's not already set
         if std::env::var("NH_FLAKE").is_err() {
-            unsafe { std::env::set_var("NH_FLAKE", f); }
+            unsafe {
+                std::env::set_var("NH_FLAKE", f);
+            }
 
             // Only warn if FLAKE is set and we're using it to set NH_FLAKE
             // AND none of the command-specific env vars are set

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -124,7 +124,7 @@ pub fn setup_environment() -> Result<bool> {
     if let Ok(f) = std::env::var("FLAKE") {
         // Set NH_FLAKE if it's not already set
         if std::env::var("NH_FLAKE").is_err() {
-            std::env::set_var("NH_FLAKE", f);
+            unsafe { std::env::set_var("NH_FLAKE", f); }
 
             // Only warn if FLAKE is set and we're using it to set NH_FLAKE
             // AND none of the command-specific env vars are set

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,8 @@
 use std::ffi::{OsStr, OsString};
 
 use color_eyre::{
-    eyre::{bail, Context},
     Result,
+    eyre::{Context, bail},
 };
 use subprocess::{Exec, ExitStatus, Redirection};
 use thiserror::Error;

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,8 +1,9 @@
 use std::env;
 
-use color_eyre::eyre::{bail, Context};
+use color_eyre::eyre::{Context, bail};
 use tracing::{debug, info, warn};
 
+use crate::Result;
 use crate::commands;
 use crate::commands::Command;
 use crate::installable::Installable;
@@ -10,7 +11,6 @@ use crate::interface::{DarwinArgs, DarwinRebuildArgs, DarwinReplArgs, DarwinSubc
 use crate::nixos::toplevel_for;
 use crate::update::update;
 use crate::util::get_hostname;
-use crate::Result;
 
 const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
 const CURRENT_PROFILE: &str = "/run/current-system";

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -39,7 +39,7 @@ pub fn from_dir(generation_dir: &Path) -> Option<u64> {
             let no_link_gen = generation_base.trim_end_matches("-link");
             no_link_gen
                 .rsplit_once('-')
-                .and_then(|(_, gen)| gen.parse::<u64>().ok())
+                .and_then(|(_, generation_num)| generation_num.parse::<u64>().ok())
         })
 }
 
@@ -137,7 +137,7 @@ pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
                 configuration_revision,
                 specialisations,
                 current: false,
-            })
+            });
         }
     };
 
@@ -155,7 +155,7 @@ pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
                 configuration_revision,
                 specialisations,
                 current: false,
-            })
+            });
         }
     };
 
@@ -194,21 +194,21 @@ pub fn print_info(mut generations: Vec<GenerationInfo>) {
 
     // Parse all dates at once and cache them
     let mut parsed_dates = HashMap::with_capacity(generations.len());
-    for gen in &generations {
-        let date = DateTime::parse_from_rfc3339(&gen.date).map_or_else(
+    for generation in &generations {
+        let date = DateTime::parse_from_rfc3339(&generation.date).map_or_else(
             |_| Local.timestamp_opt(0, 0).unwrap(),
             |dt| dt.with_timezone(&Local),
         );
         parsed_dates.insert(
-            gen.date.clone(),
+            generation.date.clone(),
             date.format("%Y-%m-%d %H:%M:%S").to_string(),
         );
     }
 
     // Sort generations by numeric value of the generation number
-    generations.sort_by_key(|gen| gen.number.parse::<u64>().unwrap_or(0));
+    generations.sort_by_key(|generation| generation.number.parse::<u64>().unwrap_or(0));
 
-    let current_generation = generations.iter().find(|gen| gen.current);
+    let current_generation = generations.iter().find(|generation| generation.current);
     debug!(?current_generation);
 
     if let Some(current) = current_generation {

--- a/src/home.rs
+++ b/src/home.rs
@@ -2,8 +2,8 @@ use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use color_eyre::eyre::bail;
 use color_eyre::Result;
+use color_eyre::eyre::bail;
 use tracing::{debug, info, warn};
 
 use crate::commands;
@@ -153,7 +153,9 @@ impl HomeRebuildArgs {
 
         if let Some(ext) = &self.backup_extension {
             info!("Using {} as the backup extension", ext);
-            unsafe { env::set_var("HOME_MANAGER_BACKUP_EXT", ext); }
+            unsafe {
+                env::set_var("HOME_MANAGER_BACKUP_EXT", ext);
+            }
         }
 
         Command::new(target_profile.get_path().join("activate"))
@@ -259,7 +261,9 @@ where
                         .to_args()
                         .join(" ")
                     };
-                    bail!("Explicitly specified home-manager configuration not found: {tried_attr_path}");
+                    bail!(
+                        "Explicitly specified home-manager configuration not found: {tried_attr_path}"
+                    );
                 }
             }
 
@@ -329,7 +333,9 @@ where
                         })
                         .collect::<Vec<_>>()
                         .join(", ");
-                    bail!("Couldn't find home-manager configuration automatically, tried: {tried_str}");
+                    bail!(
+                        "Couldn't find home-manager configuration automatically, tried: {tried_str}"
+                    );
                 }
             }
         }

--- a/src/home.rs
+++ b/src/home.rs
@@ -153,7 +153,7 @@ impl HomeRebuildArgs {
 
         if let Some(ext) = &self.backup_extension {
             info!("Using {} as the backup extension", ext);
-            env::set_var("HOME_MANAGER_BACKUP_EXT", ext);
+            unsafe { env::set_var("HOME_MANAGER_BACKUP_EXT", ext); }
         }
 
         Command::new(target_profile.get_path().join("activate"))

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -56,18 +56,18 @@ impl NHCommand {
     pub fn run(self) -> Result<()> {
         match self {
             Self::Os(args) => {
-                std::env::set_var("NH_CURRENT_COMMAND", "os");
+                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "os"); }
                 args.run()
             }
             Self::Search(args) => args.run(),
             Self::Clean(proxy) => proxy.command.run(),
             Self::Completions(args) => args.run(),
             Self::Home(args) => {
-                std::env::set_var("NH_CURRENT_COMMAND", "home");
+                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "home"); }
                 args.run()
             }
             Self::Darwin(args) => {
-                std::env::set_var("NH_CURRENT_COMMAND", "darwin");
+                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "darwin"); }
                 args.run()
             }
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use anstyle::Style;
 use clap::ValueEnum;
-use clap::{builder::Styles, Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, builder::Styles};
 
-use crate::installable::Installable;
 use crate::Result;
+use crate::installable::Installable;
 
 const fn make_style() -> Styles {
     Styles::plain().header(Style::new().bold()).literal(
@@ -56,18 +56,24 @@ impl NHCommand {
     pub fn run(self) -> Result<()> {
         match self {
             Self::Os(args) => {
-                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "os"); }
+                unsafe {
+                    std::env::set_var("NH_CURRENT_COMMAND", "os");
+                }
                 args.run()
             }
             Self::Search(args) => args.run(),
             Self::Clean(proxy) => proxy.command.run(),
             Self::Completions(args) => args.run(),
             Self::Home(args) => {
-                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "home"); }
+                unsafe {
+                    std::env::set_var("NH_CURRENT_COMMAND", "home");
+                }
                 args.run()
             }
             Self::Darwin(args) => {
-                unsafe { std::env::set_var("NH_CURRENT_COMMAND", "darwin"); }
+                unsafe {
+                    std::env::set_var("NH_CURRENT_COMMAND", "darwin");
+                }
                 args.run()
             }
         }

--- a/src/json.rs
+++ b/src/json.rs
@@ -66,18 +66,20 @@ fn test_value() {
     assert!(i.get("foo").is_ok());
     assert!(i.get("foo_bad").is_err());
     assert!(i.get("foo").unwrap().get("bar").is_ok());
-    assert!(i
-        .get("foo")
-        .unwrap()
-        .get("some")
-        .unwrap()
-        .get("other_bad")
-        .is_err());
-    assert!(i
-        .get("foo")
-        .unwrap()
-        .get("some")
-        .unwrap()
-        .get("other")
-        .is_ok());
+    assert!(
+        i.get("foo")
+            .unwrap()
+            .get("some")
+            .unwrap()
+            .get("other_bad")
+            .is_err()
+    );
+    assert!(
+        i.get("foo")
+            .unwrap()
+            .get("some")
+            .unwrap()
+            .get("other")
+            .is_ok()
+    );
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,14 +2,14 @@ use owo_colors::OwoColorize;
 use tracing::Event;
 use tracing::Level;
 use tracing::Subscriber;
-use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::FilterExt;
+use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::FormatEvent;
 use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::EnvFilter;
 
 use crate::Result;
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -2,8 +2,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use color_eyre::eyre::{bail, Context};
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::{Context, bail};
+use color_eyre::eyre::{Result, eyre};
 use tracing::{debug, info, warn};
 
 use crate::commands;
@@ -106,7 +106,9 @@ impl OsRebuildArgs {
                             .as_deref()
                             .map_or(false, |attr| attr == "vm" || attr == "vmWithBootLoader")
                     {
-                        tracing::warn!("Guessing system is {hostname} for a VM image. If this isn't intended, use --hostname to change.");
+                        tracing::warn!(
+                            "Guessing system is {hostname} for a VM image. If this isn't intended, use --hostname to change."
+                        );
                     }
                     hostname.clone()
                 }
@@ -502,7 +504,7 @@ fn find_generation_by_number(number: u64) -> Result<generations::GenerationInfo>
             None
         })
     })
-    .filter(|gen| gen.number == number.to_string())
+    .filter(|generation| generation.number == number.to_string())
     .collect();
 
     if generations.is_empty() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,14 +1,14 @@
 use std::process::Stdio;
 use std::time::Instant;
 
-use color_eyre::eyre::{bail, Context};
+use color_eyre::eyre::{Context, bail};
 use elasticsearch_dsl::{Operator, Query, Search, SearchResponse, TextQueryType};
 use interface::SearchArgs;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 
-use crate::{interface, Result};
+use crate::{Result, interface};
 
 // List of deprecated NixOS versions
 // Add new versions as they become deprecated.

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,8 +1,8 @@
 use tracing::warn;
 
+use crate::Result;
 use crate::commands::Command;
 use crate::installable::Installable;
-use crate::Result;
 
 pub fn update(installable: &Installable, input: Option<String>) -> Result<()> {
     match installable {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command as StdCommand, Stdio};
 use std::str;
 
-use color_eyre::{eyre, Result};
+use color_eyre::{Result, eyre};
 use tempfile::TempDir;
 
 use crate::commands::Command;


### PR DESCRIPTION
NixOS 25.05 is out, and we're ready to switch. Since there are no user-facing changes, this will not be making it into a new release. We also update to 2024 edition so that integration with [bloxx12/dix](https://github.com/bloxx12/dix) is possible.

## TODO

- [ ] Update `set_var` usage (it is now unsafe, and will cause compiler errors)
- [ ] Fix other deperecations/warnings implied by 2024 edition

## Notes

This will be merged before #281, and it'll probably cause a lot of merge conflicts. As such I'll probably close 281 and re-open it when I have more free time in my hands.