### PR TITLE
Fix issue #308: Ensure `builders` arg is passed to Exec on all branches.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ mkShell {
     nix-output-monitor
     taplo
     yaml-language-server
+    lldb
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Previously running `--no-nom` failed to set `--builders`.

I have also added lldb to the devShell in a second commit and I'm too lazy to open a second PR.