### PR TITLE
os repl: show output

### DIFF
--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -629,6 +629,7 @@ impl OsReplArgs {
         Command::new("nix")
             .arg("repl")
             .args(target_installable.to_args())
+            .show_output(true)
             .run()?;
 
         Ok(())


### PR DESCRIPTION
Before:

    TRACE nh::logging:86: Logging OK
    DEBUG nh:28: Main {
        verbose: false,
        command: Os(
            OsArgs {
                subcommand: Repl(
                    OsReplArgs {
                        installable: Flake {
                            reference: "/home/vin/my-flake",
                            attribute: [],
                        },
                        hostname: None,
                    },
                ),
            },
        ),
    }
    DEBUG nh:29: NH_VERSION=4.1.0 NH_REV=Some("v4.1.0")
    DEBUG nh::commands:137: cmd=Exec { nix repl '/home/vin/my-flake#nixosConfigurations.scadrial' }
    Nix 2.29.0
    Type :? for help.
    trace: Using <nixpkgs> compat wrapper...
    Loading installable 'git+file:///home/vin/my-flake#nixosConfigurations.scadrial'...
    Added 10 variables.

After:

    TRACE nh::logging:86: Logging OK
    DEBUG nh:28: Main {
        verbose: false,
        command: Os(
            OsArgs {
                subcommand: Repl(
                    OsReplArgs {
                        installable: Flake {
                            reference: "/home/vin/my-flake",
                            attribute: [],
                        },
                        hostname: None,
                    },
                ),
            },
        ),
    }
    DEBUG nh:29: NH_VERSION=4.1.0 NH_REV=None
    DEBUG nh::commands:137: cmd=Exec { nix repl '/home/vin/my-flake#nixosConfigurations.scadrial' }
    Nix 2.29.0
    Type :? for help.
    trace: Using <nixpkgs> compat wrapper...
    Loading installable 'git+file:///home/vin/my-flake#nixosConfigurations.scadrial'...
    Added 10 variables.
    nix-repl> :p 1
    1

    nix-repl>

---

Fixes https://github.com/nix-community/nh/issues/307.