### PR TITLE
checks: improve robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
+# Rust
+target
+
+# Nix
 .direnv
 result*
-target
+
+# From cargo-mutants
+mutants*
+
+# Misc
 report*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
-<!-- markdownlint-disable no-duplicate-headings -->
+<!-- markdownlint-disable no-duplicate-heading -->
 
 # NH Changelog
+
+## Unreleased
+
+### Changed
+
+- Nh checks are now more robust in the sense that unnecessary features will not
+  be required when the underlying command does not depend on them.
+
+### Fixed
+
+- Nh will now correctly detect non-semver version strings, such as `x.ygit`.
+  Instead of failing the check, we now try to normalize the string and simply
+  skip the check with a warning.
 
 ## 4.1.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,6 @@ dependencies = [
  "hostname",
  "humantime",
  "nix",
- "once_cell",
  "owo-colors",
  "proptest",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +372,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +401,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -396,6 +437,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -781,6 +823,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,11 +897,13 @@ dependencies = [
  "nix",
  "once_cell",
  "owo-colors",
+ "proptest",
  "regex",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "subprocess",
  "supports-hyperlinks",
  "system-configuration",
@@ -921,6 +975,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1034,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +1087,7 @@ checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1027,12 +1130,33 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1042,7 +1166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1052,6 +1185,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1231,10 +1382,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "semver"
@@ -1284,6 +1468,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1660,6 +1869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1941,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,20 @@ dialoguer = { version = "0.11.0", default-features = false }
 elasticsearch-dsl = "0.4.19"
 hostname = "0.4"
 humantime = "2.1.0"
-nix = { version = "0.30.1", default-features = false, features = ["fs", "user"] }
+nix = { version = "0.30.1", default-features = false, features = [
+    "fs",
+    "user",
+] }
 once_cell = "1.18.0"
 owo-colors = "4.0.0"
 regex = "1.8.4"
-reqwest = { version = "0.12.0", features = ["rustls-tls", "blocking", "json"], default-features = false }
+reqwest = { version = "0.12.0", features = [
+    "rustls-tls",
+    "blocking",
+    "json",
+], default-features = false }
 semver = "1.0.22"
-serde = { version = "1.0.166", features = [
-    "derive",
-] }
+serde = { version = "1.0.166", features = ["derive"] }
 serde_json = "1.0.100"
 subprocess = "0.2"
 supports-hyperlinks = "3.0.0"
@@ -46,9 +51,13 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "registry",
-    "std"
+    "std",
 ] }
 uzers = { version = "0.12.0", default-features = false }
 
 [target.'cfg(target_os="macos")'.dependencies]
 system-configuration = "0.6.1"
+
+[dev-dependencies]
+proptest = "1.6.0"
+serial_test = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ nix = { version = "0.30.1", default-features = false, features = [
     "fs",
     "user",
 ] }
-once_cell = "1.18.0"
 owo-colors = "4.0.0"
 regex = "1.8.4"
 reqwest = { version = "0.12.0", features = [

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,10 +1,15 @@
 use std::{cmp::Ordering, env};
 
 use color_eyre::Result;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use semver::Version;
 use tracing::{debug, warn};
 
 use crate::util::{self, NixVariant};
+
+// Static regex compiled once for version string normalization
+static VERSION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d+)\.(\d+)(?:\.(\d+))?").unwrap());
 
 /// Normalizes a version string to be compatible with semver parsing.
 ///
@@ -24,10 +29,7 @@ use crate::util::{self, NixVariant};
 /// * `String` - The normalized version string suitable for semver parsing
 fn normalize_version_string(version: &str) -> String {
     // First, try to extract a version pattern like X.Y or X.Y.Z from the beginning
-    if let Some(captures) = regex::Regex::new(r"^(\d+)\.(\d+)(?:\.(\d+))?")
-        .unwrap()
-        .captures(version)
-    {
+    if let Some(captures) = VERSION_REGEX.captures(version) {
         let major = captures.get(1).unwrap().as_str();
         let minor = captures.get(2).unwrap().as_str();
         let patch = captures.get(3).map(|m| m.as_str()).unwrap_or("0");

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,7 +1,7 @@
+use std::sync::LazyLock;
 use std::{cmp::Ordering, env};
 
 use color_eyre::Result;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use semver::Version;
 use tracing::{debug, warn};
@@ -9,7 +9,8 @@ use tracing::{debug, warn};
 use crate::util::{self, NixVariant};
 
 // Static regex compiled once for version string normalization
-static VERSION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d+)\.(\d+)(?:\.(\d+))?").unwrap());
+static VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d+)\.(\d+)(?:\.(\d+))?").unwrap());
 
 /// Normalizes a version string to be compatible with semver parsing.
 ///

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -216,7 +216,7 @@ pub struct OsRebuildArgs {
 impl OsRebuildArgs {
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
-        if env::var("NH_OS_FLAKE").is_ok() {
+        if env::var("NH_OS_FLAKE").is_ok_and(|v| !v.is_empty()) {
             return true;
         }
 
@@ -466,7 +466,7 @@ pub struct HomeRebuildArgs {
 impl HomeRebuildArgs {
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
-        if env::var("NH_HOME_FLAKE").is_ok() {
+        if env::var("NH_HOME_FLAKE").is_ok_and(|v| !v.is_empty()) {
             return true;
         }
 
@@ -494,7 +494,7 @@ pub struct HomeReplArgs {
 impl HomeReplArgs {
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
-        if env::var("NH_HOME_FLAKE").is_ok() {
+        if env::var("NH_HOME_FLAKE").is_ok_and(|v| !v.is_empty()) {
             return true;
         }
 
@@ -567,7 +567,7 @@ pub struct DarwinRebuildArgs {
 impl DarwinRebuildArgs {
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
-        if env::var("NH_DARWIN_FLAKE").is_ok() {
+        if env::var("NH_DARWIN_FLAKE").is_ok_and(|v| !v.is_empty()) {
             return true;
         }
 
@@ -589,7 +589,7 @@ pub struct DarwinReplArgs {
 impl DarwinReplArgs {
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
-        if env::var("NH_DARWIN_FLAKE").is_ok() {
+        if env::var("NH_DARWIN_FLAKE").is_ok_and(|v| !v.is_empty()) {
             return true;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
     tracing::debug!("{args:#?}");
     tracing::debug!(%NH_VERSION, ?NH_REV);
 
-    // Verify the Nix environment before running commands
+    // Check Nix version upfront
     checks::verify_nix_environment()?;
 
     // Once we assert required Nix features, validate NH environment checks

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,9 +72,23 @@ pub fn is_lix() -> Result<bool> {
     let output = Command::new("nix")
         .arg("--version")
         .run_capture()?
-        .ok_or_else(|| eyre::eyre!("No output from command"))?;
+        .ok_or_else(|| eyre::eyre!("Failed to determine Nix variant"))?;
 
     Ok(output.to_lowercase().contains("lix"))
+}
+
+/// Determines if the Nix binary is Determinate Nix
+///
+/// # Returns
+///
+/// * `Result<bool>` - True if the binary is Determinate Nix, false otherwise
+pub fn is_determinate() -> Result<bool> {
+    let output = Command::new("nix")
+        .arg("--version")
+        .run_capture()?
+        .ok_or_else(|| eyre::eyre!("Failed to determine Nix variant"))?;
+
+    Ok(output.to_lowercase().contains("determinate"))
 }
 
 /// Represents an object that may be a temporary path


### PR DESCRIPTION
Changes Nix environment checks to a trait-based, less monolithic design to avoid redundant feature checks for commands that don't require checked features in the first place. There is a performance impact, but in my experience it is... not noticable as per my testing.

Regardless I think this is more robust in design, and introduces further future-proofing the current implementation is not fully capable of. Also provides groundwork for supporting more Nix variants in the future cleanly, without utility functions to check everything one-by-one.


Fixes #305, #309

Closes #315 

