### PR TITLE
Add support for opendoas

### DIFF
--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -77,7 +77,7 @@ impl OsRebuildArgs {
             false
         } else {
             if nix::unistd::Uid::effective().is_root() {
-                bail!("Don't run nh os as root. I will call sudo internally as needed");
+                bail!("Don't run nh os as root. I will call sudo or doas internally as needed");
             }
             true
         };
@@ -344,7 +344,7 @@ impl OsRollbackArgs {
             false
         } else {
             if nix::unistd::Uid::effective().is_root() {
-                bail!("Don't run nh os as root. I will call sudo internally as needed");
+                bail!("Don't run nh os as root. I will call sudo or doas internally as needed");
             }
             true
         };


### PR DESCRIPTION
I saw that there is a closed PR that tried to add support to other privilege elevation programs, not sure as to why it was never merged, so I apologize if this PR is inappropriate because of that, that said, if the PR is welcomed here is what I added:

only support for doas, with an environment variable `NH_USE_DOAS`, if set to 1 or true, it will, well... use doas instead of sudo.

To prevent any breaking changes, I kept all the sudo logic within main.rs intact, just enclosed it on a clause to only add flags (--preserve-env and -A) if sudo is the selected helper.

For command.rs and main.rs I also added checks so doas is not run when on macos, but this is temporary, as my job will later this year provide me with a macbook, I could see about adding support for macos, at the moment I can only test on nixos/liunx.

I did a bunch of tests with and without the flag (so testing sudo and doas) and it seems like nothing broke, I hope this helps.  Of course if any changes are required I will be more than welcomed to implement them.