### PR TITLE
clean: skip directories that dont exist

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -77,12 +77,21 @@ impl interface::CleanMode {
                     bail!("nh clean user: don't run me as root!");
                 }
                 let user = nix::unistd::User::from_uid(uid)?.unwrap();
-                profiles.extend(profiles_in_dir(
-                    PathBuf::from(std::env::var("HOME")?).join(".local/state/nix/profiles"),
-                ));
-                profiles.extend(profiles_in_dir(
-                    PathBuf::from("/nix/var/nix/profiles/per-user").join(user.name),
-                ));
+
+                let xdg_profile_dir =
+                    PathBuf::from(std::env::var("HOME")?).join(".local/state/nix/profiles");
+
+                if xdg_profile_dir.is_dir() {
+                    profiles.extend(profiles_in_dir(xdg_profile_dir));
+                }
+
+                let per_user_profile_dir =
+                    PathBuf::from("/nix/var/nix/profiles/per-user").join(&user.name);
+
+                if per_user_profile_dir.is_dir() {
+                    profiles.extend(profiles_in_dir(per_user_profile_dir));
+                }
+
                 args
             }
         };


### PR DESCRIPTION
While testing https://github.com/nix-community/home-manager/pull/7341 I noticed the launchd agent reporting a failure, even though I can run it in the terminal. I noticed that it throws an error on a path that doesn't exist but continues to clean up the paths that do. Just adding some directory exists checks before attempting to clean paths. 