### PR TITLE
Show output of `nix store gc` in clean

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -241,6 +241,7 @@ impl interface::CleanMode {
                 .args(["store", "gc"])
                 .dry(args.dry)
                 .message("Performing garbage collection on the nix store")
+                .show_output(true)
                 .run()?;
         }
 


### PR DESCRIPTION
The output of `nix store gc` is just one line showing the number of paths and amount of disk space freed. This information was quite informative and it would be good to have it back.