### PR TITLE
Clean: add option that display cleanup statistics

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -241,6 +241,7 @@ impl interface::CleanMode {
                 .args(["store", "gc"])
                 .dry(args.dry)
                 .message("Performing garbage collection on the nix store")
+                .show_output(args.stats)
                 .run()?;
         }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -384,6 +384,10 @@ pub struct CleanArgs {
     /// Don't clean gcroots
     #[arg(long)]
     pub nogcroots: bool,
+
+    /// Show cleanup statistics
+    #[arg(long, short)]
+    pub stats: bool,
 }
 
 #[derive(Debug, Clone, Args)]


### PR DESCRIPTION
Very simple patch that adds option to bring back cleanup statistics.