### PR TITLE
Inspect `NH_{OS_{HOSTNAME,SPECIALISATION},HOME_{CONFIGURATION,SPECIALISATION},DARWIN_HOSTNAME}` environmental variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - `nh darwin switch` now shows the output from the `darwin-rebuild` activation.
   This allows you to see more details about the activation from `nix-darwin`, as
   well as `Home Manager`.
+- The `NH_OS_HOSTNAME`, `NH_OS_SPECIALISATION`, `NH_HOME_CONFIGURATION`,
+  `NH_HOME_SPECIALISATION`, and `NH_DARWIN_HOSTNAME` environmental variables are
+  now consulted when determining what attribute/specialisation to use.
 
 ### Fixed
 

--- a/src/home.rs
+++ b/src/home.rs
@@ -243,7 +243,10 @@ where
                     })?;
 
                 if check_res.map(|s| s.trim().to_owned()).as_deref() == Some("true") {
-                    debug!("Using explicit configuration from flag: {}", config_name);
+                    debug!(
+                        "Using explicit configuration from flag/environment: {}",
+                        config_name
+                    );
                     attribute.push(config_name);
                     if push_drv {
                         attribute.extend(toplevel.clone());

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -185,11 +185,11 @@ pub struct OsRebuildArgs {
     pub update_args: UpdateArgs,
 
     /// When using a flake installable, select this hostname from nixosConfigurations
-    #[arg(long, short = 'H', global = true)]
+    #[arg(long, short = 'H', global = true, env = "NH_OS_HOSTNAME")]
     pub hostname: Option<String>,
 
     /// Explicitly select some specialisation
-    #[arg(long, short)]
+    #[arg(long, short, env = "NH_OS_SPECIALISATION")]
     pub specialisation: Option<String>,
 
     /// Ignore specialisations
@@ -236,7 +236,7 @@ pub struct OsRollbackArgs {
     pub ask: bool,
 
     /// Explicitly select some specialisation
-    #[arg(long, short)]
+    #[arg(long, short, env = "NH_OS_SPECIALISATION")]
     pub specialisation: Option<String>,
 
     /// Ignore specialisations
@@ -280,7 +280,7 @@ pub struct OsReplArgs {
     pub installable: Installable,
 
     /// When using a flake installable, select this hostname from nixosConfigurations
-    #[arg(long, short = 'H', global = true)]
+    #[arg(long, short = 'H', global = true, env = "NH_OS_HOSTNAME")]
     pub hostname: Option<String>,
 }
 
@@ -443,11 +443,11 @@ pub struct HomeRebuildArgs {
     /// Name of the flake homeConfigurations attribute, like username@hostname
     ///
     /// If unspecified, will try <username>@<hostname> and <username>
-    #[arg(long, short)]
+    #[arg(long, short, env = "NH_HOME_CONFIGURATION")]
     pub configuration: Option<String>,
 
     /// Explicitly select some specialisation
-    #[arg(long, short)]
+    #[arg(long, short, env = "NH_HOME_SPECIALISATION")]
     pub specialisation: Option<String>,
 
     /// Ignore specialisations
@@ -483,7 +483,7 @@ pub struct HomeReplArgs {
     /// Name of the flake homeConfigurations attribute, like username@hostname
     ///
     /// If unspecified, will try <username>@<hostname> and <username>
-    #[arg(long, short)]
+    #[arg(long, short, env = "NH_HOME_CONFIGURATION")]
     pub configuration: Option<String>,
 
     /// Extra arguments passed to nix repl
@@ -556,7 +556,7 @@ pub struct DarwinRebuildArgs {
     pub update_args: UpdateArgs,
 
     /// When using a flake installable, select this hostname from darwinConfigurations
-    #[arg(long, short = 'H', global = true)]
+    #[arg(long, short = 'H', global = true, env = "NH_DARWIN_HOSTNAME")]
     pub hostname: Option<String>,
 
     /// Extra arguments passed to nix build
@@ -582,7 +582,7 @@ pub struct DarwinReplArgs {
     pub installable: Installable,
 
     /// When using a flake installable, select this hostname from darwinConfigurations
-    #[arg(long, short = 'H', global = true)]
+    #[arg(long, short = 'H', global = true, env = "NH_DARWIN_HOSTNAME")]
     pub hostname: Option<String>,
 }
 


### PR DESCRIPTION
This PR uses `clap`'s `env` attribute to specify fallback sources for specifying home configurations, NixOS/Darwin hostnames, and home/NixOS specialisations for situations where the default heuristics are insufficient.

Closes #348.