### PR TITLE
nh: annotate activation errors for nixos, HM and darwin subcommands

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-use color_eyre::eyre::{Context, bail};
+use color_eyre::eyre::{Context, bail, eyre};
 use tracing::{debug, info, warn};
 
 use crate::Result;
@@ -100,7 +100,8 @@ impl DarwinRebuildArgs {
             .extra_args(&self.extra_args)
             .message("Building Darwin configuration")
             .nom(!self.common.no_nom)
-            .run()?;
+            .run()
+            .map_err(|e| eyre!("Failed to build Darwin configuration: {}", e))?;
 
         let target_profile = out_path.get_path().to_owned();
 
@@ -144,7 +145,8 @@ impl DarwinRebuildArgs {
                 .arg(out_path.get_path())
                 .elevate(true)
                 .dry(self.common.dry)
-                .run()?;
+                .run()
+                .map_err(|e| eyre!("Failed to set Darwin system profile: {}", e))?;
 
             let darwin_rebuild = out_path.get_path().join("sw/bin/darwin-rebuild");
             let activate_user = out_path.get_path().join("activate-user");
@@ -164,7 +166,8 @@ impl DarwinRebuildArgs {
                 .elevate(needs_elevation)
                 .dry(self.common.dry)
                 .show_output(true)
-                .run()?;
+                .run()
+                .map_err(|e| eyre!("Darwin activation failed: {}", e))?;
         }
 
         // Make sure out_path is not accidentally dropped

--- a/src/home.rs
+++ b/src/home.rs
@@ -85,7 +85,10 @@ impl HomeRebuildArgs {
             .extra_args(&self.extra_args)
             .message("Building Home-Manager configuration")
             .nom(!self.common.no_nom)
-            .run()?;
+            .run()
+            .map_err(|e| {
+                color_eyre::eyre::eyre!("Failed to build Home-Manager configuration: {}", e)
+            })?;
 
         let prev_generation: Option<PathBuf> = [
             PathBuf::from("/nix/var/nix/profiles/per-user")
@@ -159,7 +162,8 @@ impl HomeRebuildArgs {
 
         Command::new(target_profile.get_path().join("activate"))
             .message("Activating configuration")
-            .run()?;
+            .run()
+            .map_err(|e| color_eyre::eyre::eyre!("Activation failed: {}", e))?;
 
         // Make sure out_path is not accidentally dropped
         // https://docs.rs/tempfile/3.12.0/tempfile/index.html#early-drop-pitfall


### PR DESCRIPTION
Switches from `?` to `map_err`, which makes it so that errors from activation/switch commands are wrapped with clear, user-facing context. Instead of propagating raw errors, failures now include explicit messages like `"Activation failed: ..."` or `"Failed to build configuration: ..."`, which should help make it obvious to the user what operation failed and why.