### PR TITLE
treewide: ensure all relevant env vars are preserved; lint

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -71,7 +71,7 @@ impl interface::CleanMode {
                                 path.read_dir()
                                     .map(|read_dir| {
                                         read_dir
-                                            .filter_map(|entry| entry.ok())
+                                            .filter_map(std::result::Result::ok)
                                             .map(|entry| entry.path())
                                             .filter(|path| path.is_dir())
                                             .flat_map(profiles_in_dir)
@@ -294,6 +294,7 @@ impl interface::CleanMode {
                 .dry(args.dry)
                 .message("Performing garbage collection on the nix store")
                 .show_output(true)
+                .with_required_env()
                 .run()?;
         }
 

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -145,6 +145,7 @@ impl DarwinRebuildArgs {
                 .arg(out_path.get_path())
                 .elevate(true)
                 .dry(self.common.dry)
+                .with_required_env()
                 .run()
                 .wrap_err("Failed to set Darwin system profile")?;
 
@@ -166,6 +167,7 @@ impl DarwinRebuildArgs {
                 .elevate(needs_elevation)
                 .dry(self.common.dry)
                 .show_output(true)
+                .with_required_env()
                 .run()
                 .wrap_err("Darwin activation failed")?;
         }
@@ -222,6 +224,7 @@ impl DarwinReplArgs {
         Command::new("nix")
             .arg("repl")
             .args(target_installable.to_args())
+            .with_required_env()
             .run()?;
 
         Ok(())

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -32,6 +32,7 @@ pub struct GenerationInfo {
     pub current: bool,
 }
 
+#[must_use]
 pub fn from_dir(generation_dir: &Path) -> Option<u64> {
     generation_dir
         .file_name()

--- a/src/home.rs
+++ b/src/home.rs
@@ -159,6 +159,7 @@ impl HomeRebuildArgs {
         }
 
         Command::new(target_profile.get_path().join("activate"))
+            .with_required_env()
             .message("Activating configuration")
             .run()
             .wrap_err("Activation failed")?;
@@ -223,6 +224,7 @@ where
                 // Verify the provided configuration exists
                 let func = format!(r#" x: x ? "{config_name}" "#);
                 let check_res = commands::Command::new("nix")
+                    .with_required_env()
                     .arg("eval")
                     .args(&extra_args)
                     .arg("--apply")
@@ -236,8 +238,7 @@ where
                     )
                     .run_capture()
                     .wrap_err(format!(
-                        "Failed running nix eval to check for explicit configuration '{}'",
-                        config_name
+                        "Failed running nix eval to check for explicit configuration '{config_name}'"
                     ))?;
 
                 if check_res.map(|s| s.trim().to_owned()).as_deref() == Some("true") {
@@ -274,6 +275,7 @@ where
                 for attr_name in [format!("{username}@{hostname}"), username] {
                     let func = format!(r#" x: x ? "{attr_name}" "#);
                     let check_res = commands::Command::new("nix")
+                        .with_required_env()
                         .arg("eval")
                         .args(&extra_args)
                         .arg("--apply")
@@ -287,8 +289,7 @@ where
                         )
                         .run_capture()
                         .wrap_err(format!(
-                            "Failed running nix eval to check for automatic configuration '{}'",
-                            attr_name
+                            "Failed running nix eval to check for automatic configuration '{attr_name}'"
                         ))?;
 
                     let current_try_attr = {
@@ -383,6 +384,7 @@ impl HomeReplArgs {
         )?;
 
         Command::new("nix")
+            .with_required_env()
             .arg("repl")
             .args(toplevel.to_args())
             .run()?;

--- a/src/installable.rs
+++ b/src/installable.rs
@@ -300,6 +300,7 @@ fn test_parse_attribute() {
 }
 
 impl Installable {
+    #[must_use]
     pub fn to_args(&self) -> Vec<String> {
         let mut res = Vec::new();
         match self {
@@ -383,6 +384,7 @@ fn test_join_attribute() {
 }
 
 impl Installable {
+    #[must_use]
     pub const fn str_kind(&self) -> &str {
         match self {
             Self::Flake { .. } => "flake",

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -58,6 +58,7 @@ pub enum NHCommand {
 }
 
 impl NHCommand {
+    #[must_use]
     pub fn get_feature_requirements(&self) -> Box<dyn FeatureRequirements> {
         match self {
             Self::Os(args) => args.get_feature_requirements(),
@@ -111,6 +112,7 @@ pub struct OsArgs {
 }
 
 impl OsArgs {
+    #[must_use]
     pub fn get_feature_requirements(&self) -> Box<dyn FeatureRequirements> {
         match &self.subcommand {
             OsSubcommand::Repl(args) => {
@@ -214,6 +216,7 @@ pub struct OsRebuildArgs {
 }
 
 impl OsRebuildArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_OS_FLAKE").is_ok_and(|v| !v.is_empty()) {
@@ -305,6 +308,7 @@ pub struct OsReplArgs {
 }
 
 impl OsReplArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_OS_FLAKE").is_ok() {
@@ -423,6 +427,7 @@ pub struct HomeArgs {
 }
 
 impl HomeArgs {
+    #[must_use]
     pub fn get_feature_requirements(&self) -> Box<dyn FeatureRequirements> {
         match &self.subcommand {
             HomeSubcommand::Repl(args) => {
@@ -484,6 +489,7 @@ pub struct HomeRebuildArgs {
 }
 
 impl HomeRebuildArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_HOME_FLAKE").is_ok_and(|v| !v.is_empty()) {
@@ -512,6 +518,7 @@ pub struct HomeReplArgs {
 }
 
 impl HomeReplArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_HOME_FLAKE").is_ok_and(|v| !v.is_empty()) {
@@ -540,6 +547,7 @@ pub struct DarwinArgs {
 }
 
 impl DarwinArgs {
+    #[must_use]
     pub fn get_feature_requirements(&self) -> Box<dyn FeatureRequirements> {
         match &self.subcommand {
             DarwinSubcommand::Repl(args) => {
@@ -585,6 +593,7 @@ pub struct DarwinRebuildArgs {
 }
 
 impl DarwinRebuildArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_DARWIN_FLAKE").is_ok_and(|v| !v.is_empty()) {
@@ -607,6 +616,7 @@ pub struct DarwinReplArgs {
 }
 
 impl DarwinReplArgs {
+    #[must_use]
     pub fn uses_flakes(&self) -> bool {
         // Check environment variables first
         if env::var("NH_DARWIN_FLAKE").is_ok_and(|v| !v.is_empty()) {

--- a/src/json.rs
+++ b/src/json.rs
@@ -29,6 +29,7 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 impl<'v> Value<'v> {
+    #[must_use]
     pub const fn new(value: &'v serde_json::Value) -> Self {
         Self {
             inner: value,

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -247,6 +247,7 @@ impl OsRebuildArgs {
                     target_profile.to_str().unwrap(),
                 ])
                 .message("Copying configuration to target")
+                .with_required_env()
                 .run()?;
         }
 
@@ -281,6 +282,7 @@ impl OsRebuildArgs {
                 .message("Activating configuration")
                 .elevate(elevate)
                 .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"])
+                .with_required_env()
                 .run()
                 .wrap_err("Activation (test) failed")?;
         }
@@ -296,6 +298,7 @@ impl OsRebuildArgs {
                 .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
                 .arg(&canonical_out_path)
                 .ssh(self.target_host.clone())
+                .with_required_env()
                 .run()
                 .wrap_err("Failed to set system profile")?;
 
@@ -327,6 +330,7 @@ impl OsRebuildArgs {
                 .elevate(elevate)
                 .message("Adding configuration to bootloader")
                 .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"])
+                .with_required_env()
                 .run()
                 .wrap_err("Bootloader activation failed")?;
         }
@@ -425,6 +429,7 @@ impl OsRollbackArgs {
             .arg(SYSTEM_PROFILE)
             .elevate(elevate)
             .message("Setting system profile")
+            .with_required_env()
             .run()
             .wrap_err("Failed to set system profile during rollback")?;
 
@@ -465,6 +470,7 @@ impl OsRollbackArgs {
             .arg("switch")
             .elevate(elevate)
             .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"])
+            .with_required_env()
             .run()
         {
             Ok(()) => {
@@ -485,6 +491,7 @@ impl OsRollbackArgs {
                         .arg(SYSTEM_PROFILE)
                         .elevate(elevate)
                         .message("Rolling back system profile")
+                        .with_required_env()
                         .run()
                         .wrap_err("NixOS: Failed to restore previous system profile after failed activation")?;
                 }
@@ -597,6 +604,7 @@ fn get_current_generation_number() -> Result<u64> {
         .wrap_err("Invalid generation number")
 }
 
+#[must_use]
 pub fn get_final_attr(build_vm: bool, with_bootloader: bool) -> String {
     let attr = if build_vm && with_bootloader {
         "vmWithBootLoader"
@@ -687,7 +695,7 @@ impl OsReplArgs {
         Command::new("nix")
             .arg("repl")
             .args(target_installable.to_args())
-            .show_output(true)
+            .with_required_env()
             .run()?;
 
         Ok(())


### PR DESCRIPTION
Ensures that all relevant NH_* variables ara preserved across command invocations. This should allow config-level overrides over variables set internally.