### PR TITLE
commands: better error propagation & env preservation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,11 +27,15 @@ please do make sure to include it above in your description.
 - Style and consistency
   - [ ] I ran **`nix fmt`** to format my Nix code
   - [ ] I ran **`cargo fmt`** to format my Rust code
+  - [ ] I have added appropriate docunentation to new code
   - [ ] My changes are consistent with the rest of the codebase
 - Correctness
   - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
 - If new changes are particularly complex:
-  - [ ] My code includes comments in particularly complex areas
+  - [ ] My code includes comments in particularly complex areas to explain the
+        logic
+  - [ ] I have documented the motive for those changes in the PR body or commit
+        description.
 - Tested on platform(s)
   - [ ] `x86_64-linux`
   - [ ] `aarch64-linux`

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,11 +36,10 @@ jobs:
 
       - name: Run Tests
         run: |
-          eval "$(nix print-dev-env)"
           set -x
 
           # Verify that tests pass
-          cargo test || exit 1
+          nix develop --command cargo test
 
       - name: Test Switching to NixOS Configuration
         run: |
@@ -58,13 +57,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Tests
-        shell: bash
         run: |
-          eval "$(nix print-dev-env)"
           set -x
 
           # Verify that tests pass
-          cargo test || exit 1
+          nix develop --command cargo test
 
       - name: Test Switching to Nix Darwin Configuration
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: "Build NH"
+name: "Test NH"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,8 @@ on:
       - ".github/workflows/build.yaml"
 
 jobs:
-  build-linux:
-    name: "Build NH on Linux"
+  test-linux:
+    name: "Test NH on Linux"
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@master
@@ -34,11 +34,20 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: nix build -L --no-link
-        name: Build
+      - name: Run Tests
+        run: |
+          eval "$(nix print-dev-env)"
+          set -x
+
+          # Verify that tests pass
+          cargo test || exit 1
+
+      - name: Test Switching to NixOS Configuration
+        run: |
+          nix run .#nh -- os switch --diff never --dry --no-nom --file ./test/configuration.nix
 
   build-darwin:
-    name: "Build NH on Darwin"
+    name: "Test NH on Darwin"
     runs-on: macos-latest
 
     steps:
@@ -48,5 +57,20 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Build NH with Nix
-        run: nix build -L --no-link
+      - name: Run Tests
+        run: |
+          eval "$(nix print-dev-env)"
+          set -x
+
+          # Verify that tests pass
+          cargo test || exit 1
+
+      - name: Test Switching to Nix Darwin Configuration
+        run: |
+          mkdir flake
+          cd flake
+          nix flake init -t nix-darwin
+          git add flake.nix
+          cd ..
+          nix run .#nh -- darwin switch --hostname simple --dry --no-nom --verbose ./flake
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Test Switching to NixOS Configuration
         run: |
-          nix run .#nh -- os switch --diff never --dry --no-nom --file ./test/configuration.nix
+          nix run .#nh -- os switch --diff never --dry --no-nom --verbose --file ./test/nixos.nix
 
   build-darwin:
     name: "Test NH on Darwin"
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Tests
+        shell: bash
         run: |
           eval "$(nix print-dev-env)"
           set -x
@@ -72,5 +73,5 @@ jobs:
           nix flake init -t nix-darwin
           git add flake.nix
           cd ..
-          nix run .#nh -- darwin switch --hostname simple --dry --no-nom --verbose ./flake
+          nix run .#nh -- darwin switch --diff never --hostname simple --dry --no-nom --verbose ./flake
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: cachix/install-nix-action@master
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - uses: actions/checkout@v4
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -126,9 +126,7 @@ impl Command {
     {
         for key in keys {
             let key_str = key.as_ref().to_string();
-            if std::env::var(&key_str).is_ok() {
-                self.env_vars.insert(key_str, EnvAction::Preserve);
-            }
+            self.env_vars.insert(key_str, EnvAction::Preserve);
         }
         self
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -797,29 +797,17 @@ mod tests {
         let sudo_exec = cmd.build_sudo_cmd();
         let cmdline = sudo_exec.to_cmdline_lossy();
 
-        #[cfg(target_os = "macos")]
-        {
-            let has_preserve_env = subprocess::Exec::cmd("sudo")
-                .args(&["--help"])
-                .stderr(subprocess::Redirection::None)
-                .stdout(subprocess::Redirection::Pipe)
-                .capture()
-                .map(|output| output.stdout_str().contains("--preserve-env"))
-                .unwrap_or(false);
-
-            if has_preserve_env {
+        // NH_SUDO_PRESERVE_ENV: set to "0" to disable --preserve-env, "1" to force, unset defaults to force
+        let preserve_env_override = std::env::var("NH_SUDO_PRESERVE_ENV").ok();
+        match preserve_env_override.as_deref() {
+            Some("0") => {
+                assert!(!cmdline.contains("--preserve-env="));
+            }
+            Some("1") | None | _ => {
                 assert!(cmdline.contains("--preserve-env="));
                 assert!(cmdline.contains("VAR1"));
                 assert!(cmdline.contains("VAR2"));
-            } else {
-                assert!(!cmdline.contains("--preserve-env="));
             }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            assert!(cmdline.contains("--preserve-env="));
-            assert!(cmdline.contains("VAR1"));
-            assert!(cmdline.contains("VAR2"));
         }
     }
 

--- a/test/configuration.nix
+++ b/test/configuration.nix
@@ -1,4 +1,12 @@
 { pkgs, ... }:
 {
+  fileSystems."/" = {
+    device = "none";
+    fsType = "tmpfs";
+    options = [ "size=1G" ];
+  };
+
+  boot.loader.grub.devices = [ "nodev" ];
+
   environment.systemPackages = [ pkgs.hello ];
 }


### PR DESCRIPTION
Fixes some of the inconsistencies left over in the commands module. This was never harmful, but the removal of leftover "bad" code will help with NH's maintenance in the long run.

1. It makes environment preservation more consistent and intuitive
2. Unifies preservation logic for Linux and Darwin
3. Cleans up code wherever I see it.

I also separated test workflows from build workflows so that we may receive more targeted feedback from the CI. While NixOS VM tests are still a future goal, this appropriately tests NH in a small scope that I find... tolerable.