### PR TITLE
clean: better interface for commands; passthru `--max`; optimise

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -407,12 +407,20 @@ pub struct CleanArgs {
     pub ask: bool,
 
     /// Don't run nix store --gc
-    #[arg(long)]
-    pub nogc: bool,
+    #[arg(long = "no-gc", alias = "nogc")]
+    pub no_gc: bool,
 
     /// Don't clean gcroots
+    #[arg(long = "no-gcroots", alias = "nogcroots")]
+    pub no_gcroots: bool,
+
+    /// Run nix-store --optimise after gc
     #[arg(long)]
-    pub nogcroots: bool,
+    pub optimise: bool,
+
+    /// Pass --max to nix store gc
+    #[arg(long)]
+    pub max: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]


### PR DESCRIPTION
Renames `--nogc` and `--nogcroots` to `--no-gc` and `--no-gcroots` respectively. This is a change in the name of consistency, and should be handled gracefully thanks to Clap's aliases. Though, you are encouraged to update your scripts or aliases in case those are deprecated in the future.

Additionally, `--optimise` and `--max` flags have been introduced. You may use the former to optimise your Nix store right after a GC and the latter to fine-grain `nix store gc`'s behaviour.


Change-Id: I6a6a69648ffe8a8abe759f773f83b1031e137981