### PR TITLE
commands: ask for SSH password locally for remote deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ functionality, under the "Removed" section.
 - Nh now supports alternative privilege escalation methods. Namely `doas`,
   `run0` and a fallback `pkexec` strategies will be attempted if the system does
   not use `sudo`.
+- Nh will correctly prompt you for your `sudo` password while deploying
+  remotely. This helps mitigating the need to allow password-less `sudo` on
+  target host to be able to deploy remotely.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ functionality, under the "Removed" section.
   `run0` and a fallback `pkexec` strategies will be attempted if the system does
   not use `sudo`.
 - Nh will correctly prompt you for your `sudo` password while deploying
-  remotely. This helps mitigating the need to allow password-less `sudo` on
-  target host to be able to deploy remotely.
+  remotely. This helps mitigate the need to allow password-less `sudo` on
+  the target host to deploy remotely.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
  "proptest",
  "regex",
  "reqwest",
+ "secrecy",
  "semver",
  "serde",
  "serde_json",
@@ -1827,6 +1828,16 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ reqwest = { default-features = false, features = [
   "blocking",
   "json",
 ], version = "0.12.23" }
+secrecy = { version = "0.8.0", features = [ "serde" ] }
 semver = "1.0.26"
 serde = { features = [ "derive" ], version = "1.0.219" }
 serde_json = "1.0.143"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ use std::{
   collections::HashMap,
   ffi::{OsStr, OsString},
   path::PathBuf,
+  sync::{Mutex, OnceLock},
 };
 
 use color_eyre::{
@@ -15,12 +16,31 @@ use which::which;
 
 use crate::{installable::Installable, interface::NixBuildPassthroughArgs};
 
-fn ssh_wrap(cmd: Exec, ssh: Option<&str>) -> Exec {
+static PASSWORD_CACHE: OnceLock<Mutex<HashMap<String, String>>> =
+  OnceLock::new();
+
+fn get_cached_password(host: &str) -> Option<String> {
+  let cache = PASSWORD_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+  cache.lock().unwrap().get(host).cloned()
+}
+
+fn cache_password(host: &str, password: String) {
+  let cache = PASSWORD_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+  cache.lock().unwrap().insert(host.to_string(), password);
+}
+
+fn ssh_wrap(cmd: Exec, ssh: Option<&str>, password: Option<&str>) -> Exec {
   if let Some(ssh) = ssh {
-    Exec::cmd("ssh")
+    let mut ssh_cmd = Exec::cmd("ssh")
       .arg("-T")
       .arg(ssh)
-      .stdin(cmd.to_cmdline_lossy().as_str())
+      .arg(cmd.to_cmdline_lossy());
+
+    if let Some(pwd) = password {
+      ssh_cmd = ssh_cmd.stdin(format!("{}\n", pwd).as_str());
+    }
+
+    ssh_cmd
   } else {
     cmd
   }
@@ -418,9 +438,72 @@ impl Command {
   ///
   /// Panics if the command result is unexpectedly None.
   pub fn run(&self) -> Result<()> {
-    let cmd = if self.elevate.is_some() {
-      self.build_sudo_cmd()?.arg(&self.command).args(&self.args)
+    // Prompt for sudo password if needed for remote deployment
+    // FIXME: this implementation only covers Sudo. I *think* doas and run0 are
+    // able to read from stdin, but needs to be tested and possibly
+    // mitigated.
+    let sudo_password = if self.ssh.is_some() && self.elevate.is_some() {
+      let host = self.ssh.as_ref().unwrap();
+      if let Some(cached_password) = get_cached_password(host) {
+        Some(cached_password)
+      } else {
+        let password =
+          inquire::Password::new(&format!("[sudo] password for {}:", host))
+            .without_confirmation()
+            .prompt()
+            .context("Failed to read sudo password")?;
+        cache_password(host, password.clone());
+        Some(password)
+      }
     } else {
+      None
+    };
+
+    let cmd = if self.elevate.is_some() && self.ssh.is_none() {
+      // Local elevation
+      self.build_sudo_cmd()?.arg(&self.command).args(&self.args)
+    } else if self.elevate.is_some() && self.ssh.is_some() {
+      // Build elevation command
+      let elevation_program = self
+        .elevate
+        .as_ref()
+        .unwrap()
+        .resolve()
+        .context("Failed to resolve elevation program")?;
+
+      let program_name = elevation_program
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+          eyre::eyre!("Failed to determine elevation program name")
+        })?;
+
+      let mut elev_cmd = Exec::cmd(&elevation_program);
+
+      // Add program-specific arguments
+      if program_name == "sudo" {
+        elev_cmd = elev_cmd.arg("--prompt=").arg("--stdin");
+      }
+
+      // Add env command to handle environment variables
+      elev_cmd = elev_cmd.arg("env");
+      for (key, action) in &self.env_vars {
+        match action {
+          EnvAction::Set(value) => {
+            elev_cmd = elev_cmd.arg(format!("{}={}", key, value));
+          },
+          EnvAction::Preserve => {
+            if let Ok(value) = std::env::var(key) {
+              elev_cmd = elev_cmd.arg(format!("{}={}", key, value));
+            }
+          },
+          _ => {},
+        }
+      }
+
+      elev_cmd.arg(&self.command).args(&self.args)
+    } else {
+      // No elevation
       self.apply_env_to_exec(Exec::cmd(&self.command).args(&self.args))
     };
 
@@ -432,6 +515,7 @@ impl Command {
         cmd.stderr(Redirection::None).stdout(Redirection::None)
       },
       self.ssh.as_deref(),
+      sudo_password.as_deref(),
     );
 
     if let Some(m) = &self.message {
@@ -1060,7 +1144,7 @@ mod tests {
   #[test]
   fn test_ssh_wrap_with_ssh() {
     let cmd = subprocess::Exec::cmd("echo").arg("hello");
-    let wrapped = ssh_wrap(cmd, Some("user@host"));
+    let wrapped = ssh_wrap(cmd, Some("user@host"), None);
 
     let cmdline = wrapped.to_cmdline_lossy();
     assert!(cmdline.starts_with("ssh"));
@@ -1071,10 +1155,21 @@ mod tests {
   #[test]
   fn test_ssh_wrap_without_ssh() {
     let cmd = subprocess::Exec::cmd("echo").arg("hello");
-    let wrapped = ssh_wrap(cmd.clone(), None);
+    let wrapped = ssh_wrap(cmd.clone(), None, None);
 
     // Should return the original command unchanged
     assert_eq!(wrapped.to_cmdline_lossy(), cmd.to_cmdline_lossy());
+  }
+
+  #[test]
+  fn test_ssh_wrap_with_password() {
+    let cmd = subprocess::Exec::cmd("echo").arg("hello");
+    let wrapped = ssh_wrap(cmd, Some("user@host"), Some("testpass"));
+
+    let cmdline = wrapped.to_cmdline_lossy();
+    assert!(cmdline.starts_with("ssh"));
+    assert!(cmdline.contains("-T"));
+    assert!(cmdline.contains("user@host"));
   }
 
   #[test]


### PR DESCRIPTION
Improves the remote deployment experience by prompting for a `sudo` password when deploying to remote hosts, rather than requiring password-less `sudo`. 

During testing I've noticed that the sudo password is prompted **3 times** (6 if we enable Inquire's confirmation) so we also introduce a password cache to avoid repeated prompts. Changelog and tests have been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote deployments now prompt for a sudo password when elevation is required.
  * Per-host password caching reduces repeated prompts during the same session.
  * Remote elevated commands better preserve relevant environment variables for improved compatibility.

* **Documentation**
  * Changelog updated to note improved remote sudo prompting, reducing the need for password-less sudo on targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->