### PR TITLE
darwin: fix activation without darwin-rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ be put in the "Changed" section or, if it's just to remove code or
 functionality, under the "Removed" section.
 -->
 
+## Unreleased
+
+### Fixed
+
+- Darwin: fall back to directly executing `activate` (and `activate-user` if
+  applicable) if `darwin-rebuild` does not exist.
+
 ## 4.2.0
 
 ### Changed


### PR DESCRIPTION
As part of supporting the new nix-darwin activation style in https://github.com/nix-community/nh/pull/238, there was a breaking change made to use `darwin-rebuild` instead of calling the activation scripts directly. Unfortunately this change meant it was no longer meant to use `nh` as a `darwin-rebuild` replacement, as it would depend on `darwin-rebuild` itself. So if `darwin-rebuild` was disabled (e.g. by setting `system.tools.enable = false`), `nh` would fail to activate the system with an error like the following:

```
> Comparing changes
<<< /run/current-system
>>> /var/folders/h7/34fnxyx94lv_hkg1fmg658fr0000gn/T/nh-osusP10v/result
No version or selection state changes.
Closure size: 2055 -> 2055 (0 paths added, 0 paths removed, delta +0, disk usage +0B).
> Activating configuration
env: ‘/var/folders/h7/34fnxyx94lv_hkg1fmg658fr0000gn/T/nh-osusP10v/result/sw/bin/darwin-rebuild’: No such file or directory
```

This PR simply adds a check whether `darwin-rebuild` exists, and if not, falls back to the old behavior.

(If it's undesirable for this configuration to be supported then perhaps a warning should be added when `activate` is used, but I think compatibility should be kept at least for now, because it was done in a minor release, and breaking changes should only happen in major releases according to semver (which is why marked it as a bug fix, since it's fixing a regression from a semver point of view))

Tested in the following cases:

- Ensure it invokes `darwin-rebuild` by default
- Ensure it falls back to `activate` if `darwin-rebuild` doesn't exist
- Ensure it also invokes `activate-user` if it's the non-deprecated version and it invoked `activate`

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/main/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate docunentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS activation is more resilient: if the standard rebuild tool isn’t available, activation falls back to direct activation and may perform a user-level activation step.
  * Automatically selects appropriate activation method and elevation based on the environment.
  * Provides clearer, more specific error messages for activation and user activation failures.

* **Documentation**
  * Added an Unreleased entry documenting the macOS activation fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->