### PR TITLE
meta: fix typos and broken link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ If your pull request includes any change or unexpected behaviour not covered bel
 please do make sure to include it above in your description.
 -->
 
-[changelog]: https://github.com/nix-community/nh/tree/main/CHANGELOG.md
+[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md
 
 - [ ] I have updated the [changelog] as per my changes
 - [ ] I have tested, and self-reviewed my code

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ all with their extensive CLI flags for extensive configuration.
 
 ### Global Subcommands
 
-- `nh search` - a super-fast package searching tool (powered by a ElasticSearch
+- `nh search` - a super-fast package searching tool (powered by an ElasticSearch
   client) for Nix packages in supported Nixpkgs branches.
   <p align="center">
     <img
@@ -275,7 +275,7 @@ NH consists of two modules. The core of NH is found in the `src` directory, and
 is separated into different modules. Some of the critical modules that you may
 want to be aware of are `nh::commands` for command interfaces, `nh::checks` for
 pre-startup checks and `nh::util` to store shared logic. Platform-specific logic
-is placed in the appropriate platfom module, such as `nh::nixos` or `nh::darwin`
+is placed in the appropriate platform module, such as `nh::nixos` or `nh::darwin`
 with generic helpers placed in `nh::util`.
 
 The `xtask` directory contains the cargo-xtask tasks used by NH, used to
@@ -293,7 +293,7 @@ Lastly, update the [changelog](/CHANGELOG.md) and open your pull request.
 [nix-output-monitor]: https://github.com/maralorn/nix-output-monitor
 [dix]: https://github.com/bloxx12/dix
 
-NH would not be possible without all thee tools we run under the hood
+NH would not be possible without all the tools we run under the hood
 
 - Tree of builds with [nix-output-monitor].
 - Visualization of the upgrade diff with [dix].


### PR DESCRIPTION
a ElasticSearch -> an ElasticSearch
platfom -> platform
thee -> the

Additionally fix broken changelog link in the pull request template, as the default branch name was changed from `main` to `master` (I think).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
