### PR TITLE
feat: add --keep-one flag to nh clean for direnv gcroots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ functionality, under the "Removed" section.
 
 ### Changed
 
+- Added `--keep-one` flag to `nh clean` which keeps one gcroot per direnv project.
 - `nh os info` now hides empty columns.
 - `nh os info` now support `--fields` to select which field(s) to display; also
   add a per-generation "Closure Size" coloumn.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -437,6 +437,10 @@ pub struct CleanArgs {
   /// At least keep gcroots and generations in this time range since now.
   pub keep_since: humantime::Duration,
 
+  /// Keep at least one gcroot per direnv project
+  #[arg(long)]
+  pub keep_one: bool,
+
   /// Only print actions, without performing them
   #[arg(long, short = 'n')]
   pub dry: bool,


### PR DESCRIPTION
The `nh clean` command now supports a `--keep-one` flag. When specified, this flag ensures the gcroot for each `direnv` project is preserved. This overrides the `--keep-since` flag for direnv roots.

I believe this should address https://github.com/nix-community/nh/issues/469 too, though I did make the change according to my needs (which is keeping the latest per project, which if I understand correctly, is what is tracked in `/nix/var/nix/gcroots/auto` for direnv gcroots).

Also, first time writing rust and first time contributor. Went for it as the change did seem straightforward enough (if I understood things correctly). Happy to make any changes as directed.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--keep-one` flag to `nh clean` command to preserve one garbage collection root per direnv project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->