### PR TITLE
generations: fix current generation flag for specialisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
-- `nh os info` support show current generation flag,
-  when actived with a specialisation  [#508](https://github.com/nix-community/nh/issues/508).
-  `nh os info` now only prefixed specialisation name with '\*' when specialisation is actived.
+- `nh os info` now shows the current generation flag,
+  when activated with a specialisation  [#508](https://github.com/nix-community/nh/issues/508).
+  `nh os info` now only prefixes the specialisation name with '\*' when the specialisation is activated.
 - `nh os info` now gracefully handles out-of-sync profiles. When a previous
   switch failed during activation (e.g., a Systemd service failed), the profile
   may be out of sync with `/run/current-system` while in "test mode" via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ functionality, under the "Removed" section.
 
 - `nh os info` now shows the current generation flag,
   when activated with a specialisation  [#508](https://github.com/nix-community/nh/issues/508).
-  `nh os info` now only prefixes the specialisation name with '\*' when the specialisation is activated.
+  - `nh os info` now only prefixes the specialisation name with '\*' when the specialisation is activated.
 - `nh os info` now gracefully handles out-of-sync profiles. When a previous
   switch failed during activation (e.g., a Systemd service failed), the profile
   may be out of sync with `/run/current-system` while in "test mode" via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `nh os info` support show current generation flag,
+  when actived with a specialisation  [#508](https://github.com/nix-community/nh/issues/508).
+  `nh os info` now only prefixed specialisation name with '\*' when specialisation is actived.
 - `nh os info` now gracefully handles out-of-sync profiles. When a previous
   switch failed during activation (e.g., a Systemd service failed), the profile
   may be out of sync with `/run/current-system` while in "test mode" via

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -257,7 +257,7 @@ pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
   let specialisations = {
     let specialisation_path = generation_dir.join("specialisation");
     if specialisation_path.exists() {
-      // Only prefixed specialisation name by '*' when it's currently actived
+      // Only prefix specialisation name with '*' when it's currently active
       let specs = fs::read_dir(specialisation_path)
         .map(|entries| {
           let mut specs_vec = entries

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -257,12 +257,23 @@ pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
   let specialisations = {
     let specialisation_path = generation_dir.join("specialisation");
     if specialisation_path.exists() {
+      // Only prefixed specialisation name by '*' when it's currently actived
       let specs = fs::read_dir(specialisation_path)
         .map(|entries| {
-          entries
+          let mut specs_vec = entries
             .filter_map(Result::ok)
-            .filter_map(|e| e.file_name().into_string().ok())
-            .collect::<Vec<String>>()
+            .filter_map(|e| {
+              if fs::canonicalize(e.path()).ok()
+                == fs::canonicalize("/run/current-system").ok()
+              {
+                Some(format!("*{}", e.file_name().into_string().ok()?))
+              } else {
+                e.file_name().into_string().ok()
+              }
+            })
+            .collect::<Vec<String>>();
+          specs_vec.sort();
+          specs_vec
         })
         .unwrap_or_default();
       if specs.is_empty() { None } else { Some(specs) }
@@ -272,39 +283,13 @@ pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
   };
 
   // Check if this generation is the current one
-  let Some(run_current_target) = fs::read_link("/run/current-system")
-    .ok()
-    .and_then(|p| fs::canonicalize(p).ok())
-  else {
-    return Some(GenerationInfo {
-      number: generation_number.to_string(),
-      date: build_date,
-      nixos_version,
-      kernel_version,
-      configuration_revision,
-      specialisations,
-      current: false,
-      closure_size,
-    });
-  };
+  let run_current_target =
+    fs::canonicalize("/nix/var/nix/profiles/system").ok();
 
-  let Some(gen_store_path) = fs::read_link(generation_dir)
-    .ok()
-    .and_then(|p| fs::canonicalize(p).ok())
-  else {
-    return Some(GenerationInfo {
-      number: generation_number.to_string(),
-      date: build_date,
-      nixos_version,
-      kernel_version,
-      configuration_revision,
-      specialisations,
-      current: false,
-      closure_size,
-    });
-  };
+  let gen_store_path = fs::canonicalize(generation_dir).ok();
 
-  let current = run_current_target == gen_store_path;
+  let current =
+    run_current_target == gen_store_path && run_current_target.is_some();
 
   Some(GenerationInfo {
     number: generation_number.to_string(),
@@ -435,13 +420,10 @@ pub fn print_info(
       .cloned()
       .unwrap_or_else(|| "Unknown".to_string());
 
-    let specialisations = generation.specialisations.as_ref().map(|specs| {
-      specs
-        .iter()
-        .map(|s| format!("*{s}"))
-        .collect::<Vec<String>>()
-        .join(" ")
-    });
+    let specialisations = generation
+      .specialisations
+      .as_ref()
+      .map(|specs| specs.join(" "));
 
     let row: String = visible_fields
       .iter()


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
Hi,
this pr is for #508 
## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * nh os info now shows the current-generation flag when run with a specialization.

* **Bug Fixes**
  * Active specialization is now marked with an asterisk (*) while other specializations are shown without per-item prefixes for clearer output.
  * Improved detection of the active generation so the info output reliably reflects which generation is current.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->