### PR TITLE
nh-clean: cleanup; improve UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,30 @@ functionality, under the "Removed" section.
 
 ## Unreleased
 
+### Added
+
+- `nh clean --keep-one` preserves all active direnv gcroots regardless of
+  `--keep-since`, preventing projects from being collected when they haven't
+  been activated recently. Orphaned and broken gcroots are still removed.
+- `nh clean --cross-filesystems` / `-x` allows the gcroot scan to cross
+  filesystem boundaries. By default the walk stays on the same filesystem as
+  `/nix/var/nix/gcroots`.
+
 ### Changed
 
 - `nh search` now uses search backend version 48 (previously 46) to track the
   current Elasticsearch endpoint.
+- gcroot scanning now walks all of `/nix/var/nix/gcroots` recursively instead of
+  only the flat `/nix/var/nix/gcroots/auto` directory.
+- Orphaned gcroots where entries in `/nix/var/nix/gcroots` whose target symlink
+  no longer exists on disk were silently skipped. They are now detected and
+  tagged for removal.
+- Broken gcroots where symlinks whose `/nix/store` target has already been
+  collected were also silently skipped. They are now tagged for removal
+  unconditionally, bypassing `--keep-since`.
+- `RESULT_REGEX` (`.*result.*`) matched any path containing the word "result",
+  including unrelated files. It is replaced by a structural check that only
+  matches direct children of `/nix/store`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,9 @@ dependencies = [
  "nh-core",
  "nix",
  "regex",
+ "tempfile",
  "tracing",
+ "walkdir",
  "yansi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ thiserror = "2.0.17"
 tracing = "0.1.41"
 tracing-subscriber = { features = [ "env-filter", "registry", "std" ], version = "0.3.20" }
 urlencoding = "2.1.3"
+walkdir = "2.5.0"
 which = "8.0.0"
 yansi = "1.0.1"
 

--- a/crates/nh-clean/Cargo.toml
+++ b/crates/nh-clean/Cargo.toml
@@ -18,7 +18,11 @@ nh-core.workspace    = true
 nix.workspace        = true
 regex.workspace      = true
 tracing.workspace    = true
+walkdir.workspace    = true
 yansi.workspace      = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/nh-clean/src/args.rs
+++ b/crates/nh-clean/src/args.rs
@@ -55,6 +55,10 @@ pub struct CleanArgs {
   /// Pass --max to nix store gc
   #[arg(long)]
   pub max: Option<String>,
+
+  /// Cross filesystem boundaries when scanning gcroots
+  #[arg(long, short = 'x')]
+  pub cross_filesystems: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/nh-clean/src/args.rs
+++ b/crates/nh-clean/src/args.rs
@@ -56,6 +56,10 @@ pub struct CleanArgs {
   #[arg(long)]
   pub max: Option<String>,
 
+  /// Keep at least one gcroot per direnv project
+  #[arg(long)]
+  pub keep_one: bool,
+
   /// Cross filesystem boundaries when scanning gcroots
   #[arg(long, short = 'x')]
   pub cross_filesystems: bool,

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -252,6 +252,10 @@ impl args::CleanMode {
             if dst.metadata().is_err() {
               debug!(?dst, "gcroot target already GC'd, tagging for removal");
               gcroots_tagged.insert(dst, true);
+            } else if args.keep_one
+              && DIRENV_REGEX.is_match(&dst.to_string_lossy())
+            {
+              gcroots_tagged.insert(dst, false);
             } else {
               let dur = now.duration_since(
                 dst
@@ -304,6 +308,9 @@ impl args::CleanMode {
       "Keeping paths newer than {}",
       Paint::new(args.keep_since).fg(Color::Green)
     );
+    if args.keep_one {
+      println!("Keeping all active direnv gcroots");
+    }
     println!();
     println!("legend:");
     println!(

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -21,6 +21,7 @@ use nix::{
 };
 use regex::Regex;
 use tracing::{Level, debug, info, instrument, span, warn};
+use walkdir::WalkDir;
 use yansi::{Color, Paint};
 
 // Nix impl:
@@ -30,11 +31,6 @@ static DIRENV_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   #[allow(clippy::expect_used)]
   Regex::new(r".*/(?:\.direnv|direnv/layouts)/.*")
     .expect("Failed to compile direnv regex")
-});
-
-static RESULT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-  #[allow(clippy::expect_used)]
-  Regex::new(r".*result.*").expect("Failed to compile result regex")
 });
 
 static GENERATION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -194,74 +190,105 @@ impl args::CleanMode {
     }
 
     // Query gcroots
-    let regexes = [&*DIRENV_REGEX, &*RESULT_REGEX];
+    let regexes = [&*DIRENV_REGEX];
+    let mut orphan_gcroots: Vec<PathBuf> = Vec::new();
 
     if !is_profile_clean && !args.no_gcroots {
-      for elem in PathBuf::from("/nix/var/nix/gcroots/auto")
-        .read_dir()
-        .wrap_err("Reading auto gcroots dir")?
+      let dirfd = nix::fcntl::open(
+        ".",
+        nix::fcntl::OFlag::O_DIRECTORY,
+        nix::sys::stat::Mode::empty(),
+      )?;
+
+      for entry in WalkDir::new("/nix/var/nix/gcroots")
+        .follow_links(false)
+        .same_file_system(!args.cross_filesystems)
+        .into_iter()
+        .filter_map(|e| {
+          e.map_err(|err| {
+            warn!(?err, "gcroot walk error");
+          })
+          .ok()
+        })
+        .filter(|e| e.path().is_symlink())
       {
-        let src = elem.wrap_err("Reading auto gcroots element")?.path();
+        let src = entry.path().to_path_buf();
         let dst = src.read_link().wrap_err("Reading symlink destination")?;
         let span = span!(Level::TRACE, "gcroot detection", ?dst);
         let _entered = span.enter();
         debug!(?src);
 
-        if !regexes
-          .iter()
-          .any(|next| next.is_match(&dst.to_string_lossy()))
-        {
-          debug!("dst doesn't match any gcroot regex, skipping");
+        if !dst.is_symlink() && !dst.exists() {
+          debug!(
+            ?src,
+            "gcroot is orphaned (dst missing), tagging for removal"
+          );
+          orphan_gcroots.push(src);
           continue;
         }
 
-        // Create a file descriptor for the current working directory
-        let dirfd = nix::fcntl::open(
-          ".",
-          nix::fcntl::OFlag::O_DIRECTORY,
-          nix::sys::stat::Mode::empty(),
-        )?;
+        let resolved_dst = if dst.is_symlink() {
+          dst.read_link().unwrap_or_else(|_| dst.clone())
+        } else {
+          dst.clone()
+        };
 
-        // Use .exists to not travel symlinks
-        if match faccessat(
+        if !regexes
+          .iter()
+          .any(|next| next.is_match(&dst.to_string_lossy()))
+          && !is_nix_store_direct_child(&resolved_dst)
+        {
+          debug!("dst doesn't match any gcroot filter, skipping");
+          continue;
+        }
+
+        match faccessat(
           &dirfd,
           &dst,
           AccessFlags::F_OK | AccessFlags::W_OK,
           AtFlags::AT_SYMLINK_NOFOLLOW,
         ) {
-          Ok(()) => true,
-          Err(errno) => {
-            match errno {
-              Errno::EACCES | Errno::ENOENT => false,
-              _ => {
-                bail!(
-                  eyre!("Checking access for gcroot {:?}, unknown error", dst)
-                    .wrap_err(errno)
-                )
-              },
+          Ok(()) => {
+            if dst.metadata().is_err() {
+              debug!(?dst, "gcroot target already GC'd, tagging for removal");
+              gcroots_tagged.insert(dst, true);
+            } else {
+              let dur = now.duration_since(
+                dst
+                  .symlink_metadata()
+                  .wrap_err("Reading gcroot metadata")?
+                  .modified()?,
+              );
+              debug!(?dur);
+              match dur {
+                Err(err) => {
+                  warn!(?err, ?now, "Failed to compare time!");
+                },
+                Ok(val) if val <= args.keep_since.into() => {
+                  gcroots_tagged.insert(dst, false);
+                },
+                Ok(_) => {
+                  gcroots_tagged.insert(dst, true);
+                },
+              }
             }
           },
-        } {
-          let dur = now.duration_since(
-            dst
-              .symlink_metadata()
-              .wrap_err("Reading gcroot metadata")?
-              .modified()?,
-          );
-          debug!(?dur);
-          match dur {
-            Err(err) => {
-              warn!(?err, ?now, "Failed to compare time!");
-            },
-            Ok(val) if val <= args.keep_since.into() => {
-              gcroots_tagged.insert(dst, false);
-            },
-            Ok(_) => {
-              gcroots_tagged.insert(dst, true);
-            },
-          }
-        } else {
-          debug!("dst doesn't exist or is not writable, skipping");
+          Err(Errno::ENOENT) => {
+            debug!(
+              ?src,
+              "gcroot is orphaned (dst missing), tagging for removal"
+            );
+            orphan_gcroots.push(src);
+          },
+          Err(Errno::EACCES) => {
+            debug!("dst not writable, skipping");
+          },
+          Err(errno) => {
+            bail!(
+              eyre!("Checking access for gcroot {:?}, unknown error", dst)
+                .wrap_err(errno)
+            )
+          },
         }
       }
     }
@@ -286,16 +313,26 @@ impl args::CleanMode {
     println!("{}: path to be kept", Paint::new("OK").fg(Color::Green));
     println!("{}: path to be removed", Paint::new("DEL").fg(Color::Red));
     println!();
+    if !orphan_gcroots.is_empty() {
+      println!("{}", Paint::new("orphaned gcroots").fg(Color::Blue).bold());
+      for path in &orphan_gcroots {
+        println!(
+          "- {} {}",
+          Paint::new("DEL").fg(Color::Red),
+          path.to_string_lossy()
+        );
+      }
+      println!();
+    }
     if !gcroots_tagged.is_empty() {
-      println!(
-        "{}",
-        Paint::new("gcroots (matching the following regex patterns)")
-          .fg(Color::Blue)
-          .bold()
-      );
+      println!("{}", Paint::new("gcroots").fg(Color::Blue).bold());
       for re in regexes {
         println!("- {}  {}", Paint::new("RE").fg(Color::Magenta), re.as_str());
       }
+      println!(
+        "- {}  /nix/store direct children",
+        Paint::new("RE").fg(Color::Magenta)
+      );
       for (path, tbr) in &gcroots_tagged {
         if *tbr {
           println!(
@@ -350,6 +387,10 @@ impl args::CleanMode {
         if *tbr {
           remove_path_nofail(path);
         }
+      }
+
+      for path in &orphan_gcroots {
+        remove_path_nofail(path);
       }
 
       for generations_tagged in profiles_tagged.values() {
@@ -507,9 +548,148 @@ fn cleanable_generations(
   Ok(result)
 }
 
+fn is_nix_store_direct_child(path: &Path) -> bool {
+  path
+    .strip_prefix("/nix/store")
+    .map(|suffix| suffix.components().count() == 1)
+    .unwrap_or(false)
+}
+
 fn remove_path_nofail(path: &Path) {
   info!("Removing {}", path.to_string_lossy());
   if let Err(err) = std::fs::remove_file(path) {
     warn!(?path, ?err, "Failed to remove path");
+  }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn store_direct_child_accepts_top_level_entry() {
+    assert!(is_nix_store_direct_child(Path::new(
+      "/nix/store/abc123zzz-foo-1.0"
+    )));
+  }
+
+  #[test]
+  fn store_direct_child_rejects_nested_path() {
+    assert!(!is_nix_store_direct_child(Path::new(
+      "/nix/store/abc123zzz-foo-1.0/bin/foo"
+    )));
+  }
+
+  #[test]
+  fn store_direct_child_rejects_store_root_itself() {
+    assert!(!is_nix_store_direct_child(Path::new("/nix/store")));
+  }
+
+  #[test]
+  fn store_direct_child_rejects_unrelated_paths() {
+    assert!(!is_nix_store_direct_child(Path::new("/home/user/result")));
+    assert!(!is_nix_store_direct_child(Path::new("/result")));
+    assert!(!is_nix_store_direct_child(Path::new(
+      "/nix/store-backup/abc"
+    )));
+  }
+
+  #[test]
+  fn direnv_regex_matches_dotdirenv_subpath() {
+    assert!(DIRENV_REGEX.is_match("/home/user/project/.direnv/python3.11"));
+  }
+
+  #[test]
+  fn direnv_regex_matches_layouts_subpath() {
+    assert!(
+      DIRENV_REGEX.is_match("/home/user/project/direnv/layouts/python3.11")
+    );
+  }
+
+  #[test]
+  fn direnv_regex_rejects_result_and_store_paths() {
+    assert!(!DIRENV_REGEX.is_match("/home/user/project/result"));
+    assert!(!DIRENV_REGEX.is_match("/nix/store/abc123zzz-foo-1.0"));
+  }
+
+  #[test]
+  fn gcroot_filter_passes_direnv_path() {
+    let path = Path::new("/home/user/project/.direnv/something");
+    let regexes = [&*DIRENV_REGEX];
+    let passes = regexes
+      .iter()
+      .any(|re| re.is_match(&path.to_string_lossy()))
+      || is_nix_store_direct_child(path);
+    assert!(passes);
+  }
+
+  #[test]
+  fn gcroot_filter_passes_store_direct_child() {
+    let path = Path::new("/nix/store/abc123zzz-foo-1.0");
+    let regexes = [&*DIRENV_REGEX];
+    let passes = regexes
+      .iter()
+      .any(|re| re.is_match(&path.to_string_lossy()))
+      || is_nix_store_direct_child(path);
+    assert!(passes);
+  }
+
+  #[test]
+  fn gcroot_filter_rejects_arbitrary_path() {
+    let path = Path::new("/home/user/some-random-link");
+    let regexes = [&*DIRENV_REGEX];
+    let passes = regexes
+      .iter()
+      .any(|re| re.is_match(&path.to_string_lossy()))
+      || is_nix_store_direct_child(path);
+    assert!(!passes);
+  }
+
+  #[test]
+  fn missing_path_triggers_case_a_condition() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let gone = dir.path().join("gone");
+    assert!(!gone.is_symlink() && !gone.exists());
+  }
+
+  #[test]
+  fn broken_symlink_does_not_trigger_case_a() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("gone");
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+    assert!(link.is_symlink());
+    assert!(!link.exists());
+    assert!(link.is_symlink() || link.exists());
+  }
+
+  #[test]
+  fn broken_symlink_metadata_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("gone");
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    assert!(link.is_symlink(), "symlink should exist");
+    assert!(
+      link.metadata().is_err(),
+      "following broken symlink should fail"
+    );
+  }
+
+  #[test]
+  fn live_symlink_metadata_succeeds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("real");
+    std::fs::write(&target, b"").expect("write");
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    assert!(link.is_symlink(), "symlink should exist");
+    assert!(
+      link.metadata().is_ok(),
+      "live symlink metadata should succeed"
+    );
   }
 }


### PR DESCRIPTION
1. Replaces loose `RESULT_REGEX` with `is_nix_store_direct_child()`, which checks for `/nix/store` direct children structurally. 
2. Fixes orphaned gcroot detection; missing dst now tags src before the filter runs, and broken symlinks whose store-path target was GC'd are tagged unconditionally. 
3. Also replaces the flat `read_dir` of `/auto` with a `WalkDir` over all of `/nix/var/nix/gcroots`, gated by `--cross-filesystems/-x` for filesystem boundary control.

Largely inspired by <https://github.com/blitz/nix-link-cleanup>. One solution I haven't fixed is non-standard Nix store paths. AFAIK Nix can have the Nix store at a non-standard path outside of `/nix` and while most systems will not do this, it's an issue I haven't tackled. There is no good way to get the correct path without parsing `nix.conf`, which I don't want to do quite honestly.

Change-Id: I8265c8f4dfc6aea938a0739f47e1fe476a6a6964

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc