### PR TITLE
nh-search: implement NixOS/home-manager option search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ functionality, under the "Removed" section.
 
 ### Added
 
+- `nh search offline <query>` subcommand for offline search using
+  [spam-db](https://github.com/feel-co/spam) databases. Requires `-D <path>` (or
+  `NH_OFFLINE_DB`) pointing to the database directory.
+- `nh search --default-search` global option to set default search mode
+  (`packages` or `options`) when no subcommand is specified.
 - `nh clean --keep-one` preserves all active direnv gcroots regardless of
   `--keep-since`, preventing projects from being collected when they haven't
   been activated recently. Orphaned and broken gcroots are still removed.
@@ -29,6 +34,13 @@ functionality, under the "Removed" section.
 
 ### Changed
 
+- **Breaking Change**: `nh search` CLI has been restructured to use subcommands.
+  - `--options <query>` is now `nh search options <query>`
+  - `--options` flag has been removed
+  - `--channel`, `--limit`, `--platforms`, and `--json` flags are now global and
+    apply to all subcommands
+  - When no subcommand is specified, the default search mode is used
+    (configurable via `--default-search`)
 - `nh search` now uses search backend version 48 (previously 46) to track the
   current Elasticsearch endpoint.
 - gcroot scanning now walks all of `/nix/var/nix/gcroots` recursively instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "nh"
-version = "4.3.2"
+version = "4.4.0-beta1"
 dependencies = [
  "anstyle",
  "clap",
@@ -1460,6 +1460,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "spam-db",
  "subprocess",
  "supports-hyperlinks",
  "textwrap",
@@ -2314,6 +2315,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spam-db"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a99b517d23c869614882fb8298c050a45b923f91a2ccf036adddd9c6b3d964"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -3262,7 +3272,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "4.3.2"
+version = "4.4.0-beta1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3389,3 +3399,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "subprocess",
  "supports-hyperlinks",
  "textwrap",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition      = "2024"
 license      = "EUPL-1.2"
 rust-version = "1.91.1"
-version      = "4.3.2"
+version      = "4.4.0-beta1"
 
 [workspace.dependencies]
 nh        = { path = "crates/nh" }
@@ -48,6 +48,7 @@ serde_json = "1.0.145"
 serial_test = "3.2.0"
 shlex = "1.3.0"
 signal-hook = "0.4.1"
+spam-db = "0.1.0"
 subprocess = "1.0.3"
 supports-hyperlinks = "3.1.0"
 system-configuration = "0.7.0"

--- a/crates/nh-search/Cargo.toml
+++ b/crates/nh-search/Cargo.toml
@@ -17,6 +17,7 @@ regex.workspace               = true
 reqwest.workspace             = true
 serde.workspace               = true
 serde_json.workspace          = true
+subprocess.workspace          = true
 supports-hyperlinks.workspace = true
 textwrap.workspace            = true
 tracing.workspace             = true

--- a/crates/nh-search/Cargo.toml
+++ b/crates/nh-search/Cargo.toml
@@ -17,6 +17,7 @@ regex.workspace               = true
 reqwest.workspace             = true
 serde.workspace               = true
 serde_json.workspace          = true
+spam-db.workspace             = true
 subprocess.workspace          = true
 supports-hyperlinks.workspace = true
 textwrap.workspace            = true

--- a/crates/nh-search/src/args.rs
+++ b/crates/nh-search/src/args.rs
@@ -1,30 +1,84 @@
-use clap::{Args, ValueEnum};
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand, ValueEnum};
 
 #[derive(Args, Debug)]
-/// Searches packages or NixOS/home-manager options by querying
-/// search.nixos.org
+/// Searches packages or NixOS/home-manager options via search.nixos.org,
+/// or a local SPAM database
 pub struct SearchArgs {
-  #[arg(long, short, default_value = "30")]
   /// Number of search results to display
+  #[arg(long, short, default_value = "30", global = true)]
   pub limit: u64,
 
+  /// Name of the channel to query (e.g nixos-23.11, nixos-unstable, etc)
   #[arg(
     long,
     short,
     env = "NH_SEARCH_CHANNEL",
-    default_value = "nixos-unstable"
+    default_value = "nixos-unstable",
+    global = true
   )]
-  /// Name of the channel to query (e.g nixos-23.11, nixos-unstable, etc)
   pub channel: String,
 
-  #[arg(long, short = 'P', env = "NH_SEARCH_PLATFORM", value_parser = clap::builder::BoolishValueParser::new())]
   /// Show supported platforms for each package
+  #[arg(
+    long,
+    short = 'P',
+    env = "NH_SEARCH_PLATFORM",
+    value_parser = clap::builder::BoolishValueParser::new(),
+    global = true
+  )]
   pub platforms: bool,
 
-  #[arg(long, short = 'j', env = "NH_SEARCH_JSON", value_parser = clap::builder::BoolishValueParser::new())]
   /// Output results as JSON
+  #[arg(
+    long,
+    short = 'j',
+    env = "NH_SEARCH_JSON",
+    value_parser = clap::builder::BoolishValueParser::new(),
+    global = true
+  )]
   pub json: bool,
 
+  /// Default search mode used when no subcommand is given.
+  /// Accepts `packages` or `options` (scope defaults to `all`).
+  #[arg(
+    long,
+    env = "NH_DEFAULT_SEARCH",
+    default_value = "packages",
+    value_name = "MODE",
+    global = true
+  )]
+  pub default_search: SearchDefault,
+
+  #[command(subcommand)]
+  pub mode: Option<SearchMode>,
+
+  /// Query shorthand: equivalent to `nh search packages <query>` or
+  /// `nh search options <query>` depending on `--default-search`
+  pub query: Vec<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SearchMode {
+  /// Search packages via search.nixos.org
+  Packages(PackagesArgs),
+  /// Search NixOS/home-manager options via search.nixos.org
+  Options(OptionsArgs),
+  /// Search local SPAM database(s) without network access
+  Offline(OfflineArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct PackagesArgs {
+  /// Name of the package to search
+  #[arg(required = true)]
+  pub query: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct OptionsArgs {
+  /// Options scope: nixpkgs, home-manager, or all (default)
   #[arg(
     long,
     num_args = 0..=1,
@@ -32,9 +86,25 @@ pub struct SearchArgs {
     require_equals = true,
     value_name = "SCOPE"
   )]
-  /// Search NixOS and home-manager module options instead of packages
-  /// SCOPE: nixpkgs, home-manager, or all (default)
-  pub options: Option<OptionScope>,
+  pub scope: Option<OptionScope>,
+
+  /// Name of the option to search
+  #[arg(required = true)]
+  pub query: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct OfflineArgs {
+  /// Path to a SPAM database file. Specify multiple times to search across
+  /// several databases
+  #[arg(
+    long = "db",
+    short = 'D',
+    value_name = "PATH",
+    env = "NH_OFFLINE_DB",
+    required = true
+  )]
+  pub databases: Vec<PathBuf>,
 
   /// Name of the package or option to search
   #[arg(required = true)]
@@ -50,6 +120,15 @@ pub enum OptionScope {
   HomeManager,
   /// Search all options (NixOS, services, and home-manager)
   All,
+}
+
+#[derive(Debug, Clone, Default, ValueEnum)]
+pub enum SearchDefault {
+  /// Search packages (default)
+  #[default]
+  Packages,
+  /// Search NixOS/home-manager options (scope defaults to `all`)
+  Options,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/nh-search/src/args.rs
+++ b/crates/nh-search/src/args.rs
@@ -102,6 +102,7 @@ pub struct OfflineArgs {
     short = 'D',
     value_name = "PATH",
     env = "NH_OFFLINE_DB",
+    value_delimiter = ':',
     required = true
   )]
   pub databases: Vec<PathBuf>,

--- a/crates/nh-search/src/args.rs
+++ b/crates/nh-search/src/args.rs
@@ -15,8 +15,7 @@ pub struct SearchArgs {
     long,
     short,
     env = "NH_SEARCH_CHANNEL",
-    default_value = "nixos-unstable",
-    global = true
+    default_value = "nixos-unstable"
   )]
   pub channel: String,
 
@@ -25,8 +24,7 @@ pub struct SearchArgs {
     long,
     short = 'P',
     env = "NH_SEARCH_PLATFORM",
-    value_parser = clap::builder::BoolishValueParser::new(),
-    global = true
+    value_parser = clap::builder::BoolishValueParser::new()
   )]
   pub platforms: bool,
 
@@ -46,8 +44,7 @@ pub struct SearchArgs {
     long,
     env = "NH_DEFAULT_SEARCH",
     default_value = "packages",
-    value_name = "MODE",
-    global = true
+    value_name = "MODE"
   )]
   pub default_search: SearchDefault,
 

--- a/crates/nh-search/src/args.rs
+++ b/crates/nh-search/src/args.rs
@@ -1,7 +1,8 @@
 use clap::{Args, ValueEnum};
 
 #[derive(Args, Debug)]
-/// Searches packages by querying search.nixos.org
+/// Searches packages or NixOS/home-manager options by querying
+/// search.nixos.org
 pub struct SearchArgs {
   #[arg(long, short, default_value = "30")]
   /// Number of search results to display
@@ -24,9 +25,31 @@ pub struct SearchArgs {
   /// Output results as JSON
   pub json: bool,
 
-  /// Name of the package to search
+  #[arg(
+    long,
+    num_args = 0..=1,
+    default_missing_value = "all",
+    require_equals = true,
+    value_name = "SCOPE"
+  )]
+  /// Search NixOS and home-manager module options instead of packages
+  /// SCOPE: nixpkgs, home-manager, or all (default)
+  pub options: Option<OptionScope>,
+
+  /// Name of the package or option to search
   #[arg(required = true)]
   pub query: Vec<String>,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum OptionScope {
+  /// Search NixOS options and modular services
+  Nixpkgs,
+  /// Search home-manager options
+  #[value(name = "home-manager")]
+  HomeManager,
+  /// Search all options (NixOS, services, and home-manager)
+  All,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/nh-search/src/search.rs
+++ b/crates/nh-search/src/search.rs
@@ -1,13 +1,14 @@
 pub mod args;
 
 use std::{
+  path::PathBuf,
   sync::OnceLock,
   time::{Duration, Instant},
 };
 
 use color_eyre::{
   Result,
-  eyre::{Context, bail, eyre},
+  eyre::{Context, bail},
 };
 use elasticsearch_dsl::{
   Operator,
@@ -18,6 +19,7 @@ use elasticsearch_dsl::{
 };
 use regex::Regex;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use spam_db::{FileRecord, OptionRecord, SpamDb};
 use subprocess::{Exec, Redirection};
 use tracing::{debug, trace, warn};
 use yansi::{Color, Paint};
@@ -106,6 +108,29 @@ struct JSONOutputOptions {
   results:    Vec<OptionSearchResult>,
 }
 
+#[derive(Debug, Serialize)]
+struct JSONOutputOffline {
+  query:      String,
+  db_paths:   Vec<String>,
+  elapsed_ms: u128,
+  options:    Vec<OfflineOptionResult>,
+  packages:   Vec<OfflinePackageResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct OfflineOptionResult {
+  db_path: String,
+  name:    String,
+  summary: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct OfflinePackageResult {
+  db_path:  String,
+  path:     String,
+  packages: Vec<String>,
+}
+
 /// Strips HTML tags from a rendered-html description string
 fn strip_html(html: &str) -> String {
   static HTML_TAG: OnceLock<Regex> = OnceLock::new();
@@ -119,14 +144,23 @@ fn strip_html(html: &str) -> String {
   re.replace_all(html, "").trim().to_string()
 }
 
-/// Returns the ES document type strings for a given option scope
+const TYPE_OPTION: &str = "option";
+const TYPE_SERVICE: &str = "service";
+const TYPE_HOME_MANAGER_OPTION: &str = "home-manager-option";
+
+const NIXPKGS_SCOPE_TYPES: &[&str] = &[TYPE_OPTION, TYPE_SERVICE];
+const HOME_MANAGER_SCOPE_TYPES: &[&str] = &[TYPE_HOME_MANAGER_OPTION];
+const ALL_SCOPE_TYPES: &[&str] =
+  &[TYPE_OPTION, TYPE_SERVICE, TYPE_HOME_MANAGER_OPTION];
+
+/// Returns the ES document type strings for a given option scope.
 const fn option_scope_types(
   scope: &args::OptionScope,
 ) -> &'static [&'static str] {
   match scope {
-    args::OptionScope::Nixpkgs => &["option", "service"],
-    args::OptionScope::HomeManager => &["home-manager-option"],
-    args::OptionScope::All => &["option", "service", "home-manager-option"],
+    args::OptionScope::Nixpkgs => NIXPKGS_SCOPE_TYPES,
+    args::OptionScope::HomeManager => HOME_MANAGER_SCOPE_TYPES,
+    args::OptionScope::All => ALL_SCOPE_TYPES,
   }
 }
 
@@ -179,10 +213,10 @@ where
        request was malformed.",
       response.status(),
     );
-    return Err(eyre!(
+    bail!(
       "search.nixos.org returned HTTP {} for channel '{channel}'",
       response.status(),
-    ));
+    );
   }
 
   let parsed_response: SearchResponse = response
@@ -194,68 +228,105 @@ where
   Ok((documents, elapsed))
 }
 
+fn capture_nix_path(args: &[&str]) -> Option<String> {
+  let capture = Exec::cmd("nix")
+    .args(args)
+    .stderr(Redirection::None)
+    .stdout(Redirection::Pipe)
+    .capture()
+    .ok()?;
+
+  capture
+    .exit_status
+    .success()
+    .then(|| capture.stdout_str().trim().to_string())
+    .filter(|path| !path.is_empty())
+}
+
+fn resolve_nixpkgs_path(channel: &str) -> String {
+  let flake_ref = if channel == "nixos-unstable" {
+    "github:NixOS/nixpkgs/nixos-unstable".to_string()
+  } else if channel.starts_with("nixos-") {
+    format!("github:NixOS/nixpkgs/{channel}")
+  } else {
+    "nixpkgs".to_string()
+  };
+
+  if let Some(path) = capture_nix_path(&["eval", "-f", "<nixpkgs>", "path"]) {
+    return path;
+  }
+
+  let flake_path = format!("{flake_ref}#path");
+  capture_nix_path(&["eval", "--raw", &flake_path]).unwrap_or_default()
+}
+
+/// Validates the channel, applying fallback for deprecated versions.
+///
+/// # Returns
+///
+/// The effective channel string, after substituting any deprecated alias with
+/// `nixos-unstable`.
+///
+/// # Errors
+///
+/// Returns an error if `channel` (post-substitution) is not a recognized
+/// branch according to [`supported_branch`].
+fn validate_channel(channel: &str) -> Result<String> {
+  let mut channel = channel.to_string();
+  if DEPRECATED_VERSIONS.contains(&channel.as_str()) {
+    warn!(
+      "Channel '{channel}' is deprecated or unavailable, falling back to \
+       'nixos-unstable'"
+    );
+    channel = "nixos-unstable".to_string();
+  }
+  if !supported_branch(&channel) {
+    bail!("Channel {channel} is not supported!");
+  }
+  Ok(channel)
+}
+
 impl args::SearchArgs {
-  #[allow(clippy::missing_errors_doc)]
+  /// Execute the search subcommand.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if no query is provided when using the shorthand form,
+  /// if the channel is unsupported, or if the underlying search request fails.
   pub fn run(&self) -> Result<()> {
     trace!("args: {self:?}");
-
-    let mut channel = self.channel.clone();
-    if DEPRECATED_VERSIONS.contains(&channel.as_str()) {
-      warn!(
-        "Channel '{channel}' is deprecated or unavailable, falling back to \
-         'nixos-unstable'"
-      );
-      channel = "nixos-unstable".to_string();
-    }
-    if !supported_branch(&channel) {
-      bail!("Channel {channel} is not supported!");
-    }
-
-    match &self.options {
-      Some(scope) => self.run_options(&channel, scope),
-      None => self.run_packages(&channel),
+    match &self.mode {
+      Some(args::SearchMode::Packages(args)) => self.run_packages(&args.query),
+      Some(args::SearchMode::Options(args)) => {
+        let scope = args.scope.as_ref().unwrap_or(&args::OptionScope::All);
+        self.run_options(scope, &args.query)
+      },
+      Some(args::SearchMode::Offline(args)) => {
+        self.run_offline(&args.databases, &args.query)
+      },
+      None => {
+        if self.query.is_empty() {
+          bail!(
+            "no query provided; try `nh search packages <query>`, `nh search \
+             options <query>`, or `nh search --help`"
+          );
+        }
+        match self.default_search {
+          args::SearchDefault::Packages => self.run_packages(&self.query),
+          args::SearchDefault::Options => {
+            self.run_options(&args::OptionScope::All, &self.query)
+          },
+        }
+      },
     }
   }
 
-  fn capture_nix_path(args: &[&str]) -> Option<String> {
-    let capture = Exec::cmd("nix")
-      .args(args)
-      .stderr(Redirection::None)
-      .stdout(Redirection::Pipe)
-      .capture()
-      .ok()?;
-
-    capture
-      .exit_status
-      .success()
-      .then(|| capture.stdout_str().trim().to_string())
-      .filter(|path| !path.is_empty())
-  }
-
-  fn resolve_nixpkgs_path(channel: &str) -> String {
-    let flake_ref = if channel == "nixos-unstable" {
-      "github:NixOS/nixpkgs/nixos-unstable".to_string()
-    } else if channel.starts_with("nixos-") {
-      format!("github:NixOS/nixpkgs/{channel}")
-    } else {
-      "nixpkgs".to_string()
-    };
-
-    if let Some(path) =
-      Self::capture_nix_path(&["eval", "-f", "<nixpkgs>", "path"])
-    {
-      return path;
-    }
-
-    let flake_path = format!("{flake_ref}#path");
-    Self::capture_nix_path(&["eval", "--raw", &flake_path]).unwrap_or_default()
-  }
-
-  fn run_packages(&self, channel: &str) -> Result<()> {
-    let query_s = self.query.join(" ");
+  fn run_packages(&self, query: &[String]) -> Result<()> {
+    let channel = validate_channel(&self.channel)?;
+    let query_s = query.join(" ");
     debug!(?query_s);
 
-    let query = Search::new().from(0).size(self.limit).query(
+    let search = Search::new().from(0).size(self.limit).query(
       Query::bool().filter(Query::term("type", "package")).must(
         Query::dis_max()
           .tie_breaker(0.7)
@@ -293,8 +364,8 @@ impl args::SearchArgs {
       println!("Querying search.nixos.org, with channel {channel}...");
     }
     let (documents, elapsed) = search_documents::<SearchResult>(
-      &query,
-      channel,
+      &search,
+      &channel,
       "building search query",
       "querying the elasticsearch API",
       "parsing search document",
@@ -307,20 +378,18 @@ impl args::SearchArgs {
     }
 
     if self.json {
-      // Output as JSON
       let json_output = JSONOutput {
-        query:      query_s,
-        channel:    channel.to_string(),
+        query: query_s,
+        channel,
         elapsed_ms: elapsed.as_millis(),
-        results:    documents,
+        results: documents,
       };
 
       println!("{}", serde_json::to_string_pretty(&json_output)?);
       return Ok(());
     }
 
-    let nixpkgs_path = Self::resolve_nixpkgs_path(channel);
-
+    let nixpkgs_path = resolve_nixpkgs_path(&channel);
     debug!("nixpkgs_path: {:?}", nixpkgs_path);
 
     for elem in documents.iter().rev() {
@@ -354,8 +423,6 @@ impl args::SearchArgs {
       if let Some(package_position) = &elem.package_position {
         match package_position.split(':').next() {
           Some(position) => {
-            // Position from search.nixos.org is already a relative path
-            // like "pkgs/by-name/..."
             if !nixpkgs_path.is_empty() {
               print!("  Defined at: ");
               print_hyperlink(
@@ -386,15 +453,16 @@ impl args::SearchArgs {
 
   fn run_options(
     &self,
-    channel: &str,
     scope: &args::OptionScope,
+    query: &[String],
   ) -> Result<()> {
-    let query_s = self.query.join(" ");
+    let channel = validate_channel(&self.channel)?;
+    let query_s = query.join(" ");
     debug!(?query_s, ?scope);
 
     let option_types = option_scope_types(scope);
 
-    let query = Search::new().from(0).size(self.limit).query(
+    let search = Search::new().from(0).size(self.limit).query(
       Query::bool()
         .filter(Query::terms("type", option_types))
         .must(
@@ -436,8 +504,8 @@ impl args::SearchArgs {
       );
     }
     let (documents, elapsed) = search_documents::<OptionSearchResult>(
-      &query,
-      channel,
+      &search,
+      &channel,
       "building option search query",
       "querying the elasticsearch API for options",
       "parsing option search document",
@@ -451,18 +519,18 @@ impl args::SearchArgs {
 
     if self.json {
       let json_output = JSONOutputOptions {
-        query:      query_s,
-        channel:    channel.to_string(),
-        scope:      option_scope_label(scope).to_string(),
+        query: query_s,
+        channel,
+        scope: option_scope_label(scope).to_string(),
         elapsed_ms: elapsed.as_millis(),
-        results:    documents,
+        results: documents,
       };
 
       println!("{}", serde_json::to_string_pretty(&json_output)?);
       return Ok(());
     }
 
-    let nixpkgs_path = Self::resolve_nixpkgs_path(channel);
+    let nixpkgs_path = resolve_nixpkgs_path(&channel);
     debug!("nixpkgs_path: {:?}", nixpkgs_path);
 
     for elem in documents.iter().rev() {
@@ -529,6 +597,147 @@ impl args::SearchArgs {
             "https://github.com/NixOS/nixpkgs/blob/{channel}/{filepath}"
           );
           print_hyperlink(&url, &url);
+        }
+      }
+    }
+
+    Ok(())
+  }
+
+  #[allow(clippy::cast_possible_truncation)]
+  fn run_offline(&self, databases: &[PathBuf], query: &[String]) -> Result<()> {
+    let query_s = query.join(" ");
+    debug!(?query_s);
+
+    let db_paths: Vec<String> =
+      databases.iter().map(|p| p.display().to_string()).collect();
+
+    let then = Instant::now();
+
+    let mut option_results: Vec<(String, OptionRecord)> = Vec::new();
+    let mut package_results: Vec<(String, FileRecord)> = Vec::new();
+
+    for db_path in databases {
+      let db = SpamDb::open(db_path).with_context(|| {
+        format!("opening SPAM database: {}", db_path.display())
+      })?;
+
+      let db_label = db_path.display().to_string();
+
+      match db {
+        SpamDb::Options(opts_db) => {
+          let records = opts_db.query(&query_s).with_context(|| {
+            format!("querying options database: {}", db_path.display())
+          })?;
+          for rec in records {
+            option_results.push((db_label.clone(), rec));
+          }
+        },
+        SpamDb::Packages(pkgs_db) => {
+          let records = pkgs_db.query(&query_s).with_context(|| {
+            format!("querying packages database: {}", db_path.display())
+          })?;
+          for rec in records {
+            package_results.push((db_label.clone(), rec));
+          }
+        },
+      }
+    }
+
+    let elapsed = then.elapsed();
+
+    if self.json {
+      let limit = self.limit as usize;
+      let opt_len = option_results.len().min(limit);
+      let pkg_remaining = limit.saturating_sub(opt_len);
+      let pkg_len = package_results.len().min(pkg_remaining);
+
+      option_results.truncate(opt_len);
+      package_results.truncate(pkg_len);
+
+      let offline_opts: Vec<OfflineOptionResult> = option_results
+        .into_iter()
+        .map(|(db_path, rec)| {
+          OfflineOptionResult {
+            db_path,
+            name: rec.name,
+            summary: rec.summary,
+          }
+        })
+        .collect();
+
+      let offline_pkgs: Vec<OfflinePackageResult> = package_results
+        .into_iter()
+        .map(|(db_path, rec)| {
+          OfflinePackageResult {
+            db_path,
+            path: rec.path,
+            packages: rec.packages,
+          }
+        })
+        .collect();
+
+      let json_output = JSONOutputOffline {
+        query: query_s,
+        db_paths,
+        elapsed_ms: elapsed.as_millis(),
+        options: offline_opts,
+        packages: offline_pkgs,
+      };
+
+      println!("{}", serde_json::to_string_pretty(&json_output)?);
+      return Ok(());
+    }
+
+    println!("Searching {} offline database(s)...", databases.len());
+    println!("Took {}ms", elapsed.as_millis());
+    println!();
+
+    let total_results = option_results.len() + package_results.len();
+    if total_results == 0 {
+      println!("No results found.");
+      return Ok(());
+    }
+
+    let limit = self.limit as usize;
+    let mut shown = 0usize;
+
+    for (db_path, rec) in &option_results {
+      if shown >= limit {
+        break;
+      }
+      shown += 1;
+
+      println!();
+      print!("{}", Paint::new(&rec.name).fg(Color::Blue));
+      println!();
+      println!("  Source: {db_path}");
+
+      if let Some(ref summary) = rec.summary {
+        let summary = summary.replace('\n', " ");
+        for line in
+          textwrap::wrap(&summary, textwrap::Options::with_termwidth())
+        {
+          println!("  {line}");
+        }
+      }
+    }
+
+    for (db_path, rec) in &package_results {
+      if shown >= limit {
+        break;
+      }
+      shown += 1;
+
+      println!();
+      print!("{}", Paint::new(&rec.path).fg(Color::Blue));
+      println!();
+      println!("  Source: {db_path}");
+
+      if !rec.packages.is_empty() {
+        let pkgs = rec.packages.join(", ");
+        for line in textwrap::wrap(&pkgs, textwrap::Options::with_termwidth()) {
+          println!("  Packages: {line}");
         }
       }
     }

--- a/crates/nh-search/src/search.rs
+++ b/crates/nh-search/src/search.rs
@@ -1,10 +1,13 @@
 pub mod args;
 
-use std::{process::Stdio, sync::OnceLock, time::Instant};
+use std::{
+  sync::OnceLock,
+  time::{Duration, Instant},
+};
 
 use color_eyre::{
   Result,
-  eyre::{Context, bail},
+  eyre::{Context, bail, eyre},
 };
 use elasticsearch_dsl::{
   Operator,
@@ -14,7 +17,8 @@ use elasticsearch_dsl::{
   TextQueryType,
 };
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use subprocess::{Exec, Redirection};
 use tracing::{debug, trace, warn};
 use yansi::{Color, Paint};
 
@@ -51,6 +55,21 @@ struct SearchResult {
   package_position:        Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[allow(non_snake_case, dead_code)]
+struct OptionSearchResult {
+  r#type:             String,
+  option_name:        String,
+  option_description: Option<String>,
+  option_type:        Option<String>,
+  option_default:     Option<String>,
+  option_example:     Option<String>,
+  option_source:      Option<String>,
+  option_flake:       Option<Vec<String>>,
+  flake_name:         Option<String>,
+  flake_description:  Option<String>,
+}
+
 // Cache the hyperlink support check result
 static HYPERLINKS_SUPPORTED: OnceLock<bool> = OnceLock::new();
 
@@ -78,6 +97,103 @@ struct JSONOutput {
   results:    Vec<SearchResult>,
 }
 
+#[derive(Debug, Serialize)]
+struct JSONOutputOptions {
+  query:      String,
+  channel:    String,
+  scope:      String,
+  elapsed_ms: u128,
+  results:    Vec<OptionSearchResult>,
+}
+
+/// Strips HTML tags from a rendered-html description string
+fn strip_html(html: &str) -> String {
+  static HTML_TAG: OnceLock<Regex> = OnceLock::new();
+  let re = HTML_TAG.get_or_init(|| {
+    Regex::new(r"<[^>]*>").unwrap_or_else(|e| {
+      warn!("invalid HTML strip regex: {e}");
+      #[allow(clippy::expect_used)]
+      Regex::new("$^").expect("Regex $^ should always be valid")
+    })
+  });
+  re.replace_all(html, "").trim().to_string()
+}
+
+/// Returns the ES document type strings for a given option scope
+const fn option_scope_types(
+  scope: &args::OptionScope,
+) -> &'static [&'static str] {
+  match scope {
+    args::OptionScope::Nixpkgs => &["option", "service"],
+    args::OptionScope::HomeManager => &["home-manager-option"],
+    args::OptionScope::All => &["option", "service", "home-manager-option"],
+  }
+}
+
+const fn option_scope_label(scope: &args::OptionScope) -> &'static str {
+  match scope {
+    args::OptionScope::Nixpkgs => "nixpkgs",
+    args::OptionScope::HomeManager => "home-manager",
+    args::OptionScope::All => "all",
+  }
+}
+
+fn search_documents<T>(
+  query: &Search,
+  channel: &str,
+  build_context: &'static str,
+  execute_context: &'static str,
+  parse_context: &'static str,
+) -> Result<(Vec<T>, Duration)>
+where
+  T: DeserializeOwned,
+{
+  let then = Instant::now();
+  let client = reqwest::blocking::Client::new();
+  let req = client
+    // NOTE: when the version of the backend API changes,
+    // this file and the corresponding workflow called
+    // nixos-search.yaml have to be updated accordingly.
+    .post(format!(
+      "https://search.nixos.org/backend/latest-48-{channel}/_search"
+    ))
+    .json(query)
+    .header("User-Agent", format!("nh/{NH_VERSION}"))
+    // Hardcoded upstream
+    // https://github.com/NixOS/nixos-search/blob/744ec58e082a3fcdd741b2c9b0654a0f7fda4603/frontend/src/index.js
+    .basic_auth("aWVSALXpZv", Some("X8gPHnzL52wFEekuxsfQ9cSh"))
+    .build()
+    .context(build_context)?;
+
+  debug!(?req);
+
+  let response = client.execute(req).context(execute_context)?;
+  let elapsed = then.elapsed();
+  debug!(?elapsed);
+  trace!(?response);
+
+  if !response.status().is_success() {
+    eprintln!(
+      "Error: search.nixos.org returned HTTP {} for channel '{channel}'. This \
+       usually means the channel does not exist, is not indexed, or the \
+       request was malformed.",
+      response.status(),
+    );
+    return Err(eyre!(
+      "search.nixos.org returned HTTP {} for channel '{channel}'",
+      response.status(),
+    ));
+  }
+
+  let parsed_response: SearchResponse = response
+    .json()
+    .context("parsing response into the elasticsearch format")?;
+  trace!(?parsed_response);
+
+  let documents = parsed_response.documents::<T>().context(parse_context)?;
+  Ok((documents, elapsed))
+}
+
 impl args::SearchArgs {
   #[allow(clippy::missing_errors_doc)]
   pub fn run(&self) -> Result<()> {
@@ -95,30 +211,47 @@ impl args::SearchArgs {
       bail!("Channel {channel} is not supported!");
     }
 
+    match &self.options {
+      Some(scope) => self.run_options(&channel, scope),
+      None => self.run_packages(&channel),
+    }
+  }
+
+  fn capture_nix_path(args: &[&str]) -> Option<String> {
+    let capture = Exec::cmd("nix")
+      .args(args)
+      .stderr(Redirection::None)
+      .stdout(Redirection::Pipe)
+      .capture()
+      .ok()?;
+
+    capture
+      .exit_status
+      .success()
+      .then(|| capture.stdout_str().trim().to_string())
+      .filter(|path| !path.is_empty())
+  }
+
+  fn resolve_nixpkgs_path(channel: &str) -> String {
     let flake_ref = if channel == "nixos-unstable" {
       "github:NixOS/nixpkgs/nixos-unstable".to_string()
     } else if channel.starts_with("nixos-") {
       format!("github:NixOS/nixpkgs/{channel}")
     } else {
-      "nixpkgs".to_string() // fallback to registry default
+      "nixpkgs".to_string()
     };
 
-    let nixpkgs_path = std::thread::spawn(move || {
-      if let Ok(output) = std::process::Command::new("nix")
-        .stderr(Stdio::null())
-        .args(["eval", "-f", "<nixpkgs>", "path"])
-        .output()
-        && output.status.success()
-      {
-        return Ok(output);
-      }
+    if let Some(path) =
+      Self::capture_nix_path(&["eval", "-f", "<nixpkgs>", "path"])
+    {
+      return path;
+    }
 
-      std::process::Command::new("nix")
-        .stderr(Stdio::null())
-        .args(["eval", "--raw", &format!("{flake_ref}#path")])
-        .output()
-    });
+    let flake_path = format!("{flake_ref}#path");
+    Self::capture_nix_path(&["eval", "--raw", &flake_path]).unwrap_or_default()
+  }
 
+  fn run_packages(&self, channel: &str) -> Result<()> {
     let query_s = self.query.join(" ");
     debug!(?query_s);
 
@@ -157,52 +290,15 @@ impl args::SearchArgs {
     );
 
     if !self.json {
-      println!(
-        "Querying search.nixos.org, with channel {}...",
-        self.channel
-      );
+      println!("Querying search.nixos.org, with channel {channel}...");
     }
-    let then = Instant::now();
-
-    let client = reqwest::blocking::Client::new();
-    let req = client
-            // NOTE: when the version of the backend API changes,
-            // this file and the corresponding workflow called
-            // nixos-search.yaml have to be updated accordingly.
-            .post(format!(
-                "https://search.nixos.org/backend/latest-48-{channel}/_search"
-            ))
-            .json(&query)
-            .header("User-Agent", format!("nh/{NH_VERSION}"))
-            // Hardcoded upstream
-            // https://github.com/NixOS/nixos-search/blob/744ec58e082a3fcdd741b2c9b0654a0f7fda4603/frontend/src/index.js
-            .basic_auth("aWVSALXpZv", Some("X8gPHnzL52wFEekuxsfQ9cSh"))
-            .build()
-            .context("building search query")?;
-
-    debug!(?req);
-
-    let response = client
-      .execute(req)
-      .context("querying the elasticsearch API")?;
-    let elapsed = then.elapsed();
-    debug!(?elapsed);
-    trace!(?response);
-
-    if !response.status().is_success() {
-      eprintln!(
-        "Error: search.nixos.org returned HTTP {} for channel '{}'. This \
-         usually means the channel does not exist, is not indexed, or the \
-         request was malformed.",
-        response.status(),
-        self.channel
-      );
-      return Err(color_eyre::eyre::eyre!(
-        "search.nixos.org returned HTTP {} for channel '{}'",
-        response.status(),
-        self.channel
-      ));
-    }
+    let (documents, elapsed) = search_documents::<SearchResult>(
+      &query,
+      channel,
+      "building search query",
+      "querying the elasticsearch API",
+      "parsing search document",
+    )?;
 
     if !self.json {
       println!("Took {}ms", elapsed.as_millis());
@@ -210,44 +306,20 @@ impl args::SearchArgs {
       println!();
     }
 
-    let parsed_response: SearchResponse = response
-      .json()
-      .context("parsing response into the elasticsearch format")?;
-    trace!(?parsed_response);
-
-    let documents = parsed_response
-      .documents::<SearchResult>()
-      .context("parsing search document")?;
-
     if self.json {
       // Output as JSON
       let json_output = JSONOutput {
-        query: query_s,
-        channel,
+        query:      query_s,
+        channel:    channel.to_string(),
         elapsed_ms: elapsed.as_millis(),
-        results: documents,
+        results:    documents,
       };
 
       println!("{}", serde_json::to_string_pretty(&json_output)?);
       return Ok(());
     }
 
-    let nixpkgs_path_output = nixpkgs_path.join().map_err(|e| {
-      color_eyre::eyre::eyre!("nixpkgs_path thread panicked: {e:?}")
-    })?;
-    debug!("{nixpkgs_path_output:?}");
-
-    let nixpkgs_path = nixpkgs_path_output
-      .ok()
-      .and_then(|output| {
-        if output.status.success() {
-          String::from_utf8(output.stdout).ok()
-        } else {
-          None
-        }
-      })
-      .map(|s| s.trim().to_string())
-      .unwrap_or_default();
+    let nixpkgs_path = Self::resolve_nixpkgs_path(channel);
 
     debug!("nixpkgs_path: {:?}", nixpkgs_path);
 
@@ -305,6 +377,158 @@ impl args::SearchArgs {
                {package_position}"
             );
           },
+        }
+      }
+    }
+
+    Ok(())
+  }
+
+  fn run_options(
+    &self,
+    channel: &str,
+    scope: &args::OptionScope,
+  ) -> Result<()> {
+    let query_s = self.query.join(" ");
+    debug!(?query_s, ?scope);
+
+    let option_types = option_scope_types(scope);
+
+    let query = Search::new().from(0).size(self.limit).query(
+      Query::bool()
+        .filter(Query::terms("type", option_types))
+        .must(
+          Query::dis_max()
+            .tie_breaker(0.7)
+            .query(
+              Query::multi_match(
+                [
+                  "option_name^6",
+                  "option_name.*^3.6",
+                  "option_name_query^6",
+                  "option_name_query.*^3.6",
+                  "option_description^1",
+                  "option_description.*^0.6",
+                  "flake_name^0.5",
+                  "flake_name.*^0.3",
+                  "service_package^3",
+                  "service_package.*^1.8",
+                  "service_packages^3",
+                  "service_packages.*^1.8",
+                ],
+                query_s.clone(),
+              )
+              .r#type(TextQueryType::CrossFields)
+              .analyzer("whitespace")
+              .auto_generate_synonyms_phrase_query(false)
+              .operator(Operator::And),
+            )
+            .query(
+              Query::wildcard("option_name", format!("*{}*", &query_s))
+                .case_insensitive(true),
+            ),
+        ),
+    );
+
+    if !self.json {
+      println!(
+        "Querying options on search.nixos.org, with channel {channel}..."
+      );
+    }
+    let (documents, elapsed) = search_documents::<OptionSearchResult>(
+      &query,
+      channel,
+      "building option search query",
+      "querying the elasticsearch API for options",
+      "parsing option search document",
+    )?;
+
+    if !self.json {
+      println!("Took {}ms", elapsed.as_millis());
+      println!("Most relevant results at the end");
+      println!();
+    }
+
+    if self.json {
+      let json_output = JSONOutputOptions {
+        query:      query_s,
+        channel:    channel.to_string(),
+        scope:      option_scope_label(scope).to_string(),
+        elapsed_ms: elapsed.as_millis(),
+        results:    documents,
+      };
+
+      println!("{}", serde_json::to_string_pretty(&json_output)?);
+      return Ok(());
+    }
+
+    let nixpkgs_path = Self::resolve_nixpkgs_path(channel);
+    debug!("nixpkgs_path: {:?}", nixpkgs_path);
+
+    for elem in documents.iter().rev() {
+      println!();
+      trace!("{elem:#?}");
+
+      print!("{}", Paint::new(&elem.option_name).fg(Color::Blue));
+
+      if let Some(ref ot) = elem.option_type {
+        print!(" :: {}", Paint::new(ot).fg(Color::Green));
+      }
+
+      if let Some(ref oe) = elem.option_example {
+        print!(" (example: {})", Paint::new(oe).fg(Color::Yellow));
+      }
+
+      println!();
+      println!("  Scope: {}", elem.r#type);
+
+      if let Some(ref desc) = elem.option_description {
+        let desc = strip_html(desc);
+        let desc = desc.replace('\n', " ");
+        for line in textwrap::wrap(&desc, textwrap::Options::with_termwidth()) {
+          println!("  {line}");
+        }
+      }
+
+      if let Some(ref default) = elem.option_default {
+        let prefix = "  Default: ";
+        for (i, line) in
+          textwrap::wrap(default, textwrap::Options::with_termwidth())
+            .iter()
+            .enumerate()
+        {
+          if i == 0 {
+            println!("{prefix}{line}");
+          } else {
+            println!("           {line}");
+          }
+        }
+      }
+
+      if let Some(ref source) = elem.option_source {
+        let is_hm = elem.r#type == "home-manager-option";
+        let filepath = source.split(':').next().unwrap_or(source);
+
+        if !is_hm && !nixpkgs_path.is_empty() {
+          print!("  Defined at: ");
+          print_hyperlink(
+            filepath,
+            &format!("file://{nixpkgs_path}/{filepath}"),
+          );
+        }
+
+        print!("  Source: ");
+        if is_hm {
+          let url = format!(
+            "https://github.com/nix-community/home-manager/blob/master/\
+             {filepath}"
+          );
+          print_hyperlink(&url, &url);
+        } else {
+          let url = format!(
+            "https://github.com/NixOS/nixpkgs/blob/{channel}/{filepath}"
+          );
+          print_hyperlink(&url, &url);
         }
       }
     }

--- a/crates/nh-search/src/search.rs
+++ b/crates/nh-search/src/search.rs
@@ -648,12 +648,17 @@ impl args::SearchArgs {
 
     if self.json {
       let limit = self.limit as usize;
-      let opt_len = option_results.len().min(limit);
-      let pkg_remaining = limit.saturating_sub(opt_len);
-      let pkg_len = package_results.len().min(pkg_remaining);
+      // Split the budget evenly; if one category has fewer results than its
+      // half, the surplus flows to the other.
+      let half = limit / 2;
+      let opt_take = option_results.len().min(half);
+      let pkg_take = package_results.len().min(limit - opt_take);
+      // Redistribute any budget packages didn't consume back to options.
+      let opt_take = opt_take
+        + (limit - opt_take - pkg_take).min(option_results.len() - opt_take);
 
-      option_results.truncate(opt_len);
-      package_results.truncate(pkg_len);
+      option_results.truncate(opt_take);
+      package_results.truncate(pkg_take);
 
       let offline_opts: Vec<OfflineOptionResult> = option_results
         .into_iter()
@@ -700,6 +705,16 @@ impl args::SearchArgs {
     }
 
     let limit = self.limit as usize;
+    // Same fair split as the JSON path: each category gets at most half,
+    // with surplus from one flowing to the other.
+    let half = limit / 2;
+    let opt_take = option_results.len().min(half);
+    let pkg_take = package_results.len().min(limit - opt_take);
+    let opt_take = opt_take
+      + (limit - opt_take - pkg_take).min(option_results.len() - opt_take);
+    option_results.truncate(opt_take);
+    package_results.truncate(pkg_take);
+
     let mut shown = 0usize;
 
     for (db_path, rec) in &option_results {

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,9 +223,29 @@ experience, done so with two subcommands provided out of the box.
 
 #### `nh search`
 
-We provide a super-fast package searching tool (powered by an Elasticsearch
-client) for Nix packages in supported Nixpkgs branches, available as
-`nh search`.
+[SPAM]: https://github.com/nix-community/SPAM
+
+We provide a super-fast search tool for Nix packages and NixOS/Home Manager
+options (powered by an Elasticsearch client against search.nixos.org), as well
+as offline search against local [SPAM] databases. All available as `nh search`!
+
+The command exposes three explicit subcommands and a convenient shorthand:
+
+<!--markdownlint-disable MD013 -->
+
+[found here]: https://github.com/feel-co/spam/actions/workflows/auto-index.yml
+
+| Invocation                                    | What it does                                                                            |
+| --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `nh search <query>`                           | Shorthand; searches packages by default (see `NH_DEFAULT_SEARCH`)                       |
+| `nh search packages <query>`                  | Search Nixpkgs packages via search.nixos.org                                            |
+| `nh search options [--scope=<SCOPE>] <query>` | Search NixOS/Home Manager options (`--scope`: `nixpkgs`, `home-manager`, `all`)         |
+| `nh search offline --db <PATH> <query>`       | Search a local SPAM database without network access. Generated DBs can be [found here]. |
+
+<!--markdownlint-enable MD013 -->
+
+Common flags (`--limit`, `--channel`, `--json`, `--platforms`) apply to all
+subcommands and can be placed before or after the subcommand name.
 
 <p align="center">
     <img
@@ -376,6 +396,30 @@ the common variables that you may encounter or choose to employ are as follows:
 - `NH_LOG`
   - Sets the tracing/log filter for NH. This uses the same format as
     `tracing_subscriber` env filters (for example: `nh=trace`).
+
+- `NH_SEARCH_CHANNEL`
+  - Default Nixpkgs channel used by `nh search packages` and `nh search options`
+    (e.g. `nixos-unstable`, `nixos-24.11`). Overridden per-invocation by
+    `--channel`.
+
+- `NH_SEARCH_JSON`
+  - When set to a truthy value, `nh search` outputs results as raw JSON instead
+    of the formatted display. Equivalent to `--json`.
+
+- `NH_SEARCH_PLATFORM`
+  - When set to a truthy value, supported platforms are shown for each package
+    result. Equivalent to `--platforms`.
+
+- `NH_DEFAULT_SEARCH`
+  - Controls the target of the `nh search <query>` shorthand when no subcommand
+    is given. Accepted values: `packages` (default), `options` (uses scope
+    `all`). Equivalent to `--default-search`.
+
+- `NH_OFFLINE_DB`
+  - Colon-separated list of paths to SPAM database files used by
+    `nh search offline`. Each path is treated as a separate database. Equivalent
+    to passing `--db` multiple times. Example:
+    `NH_OFFLINE_DB=/var/cache/spam/nixpkgs.db:/var/cache/spam/hm.db`.
 
 - `NH_NOM`
   - Control whether `nom` (nix-output-monitor) should be enabled for the build


### PR DESCRIPTION
Was bound to happen at some point. Adds support for searching NixOS and home-manager options in addition to packages in `nh search` using the new `--options[=SCOPE]` argument. Also refactors and generalizes the search logic for structure and maintainability. I reckon we'll do some more work on search in the future (especially around *offline* search) so I decided it's a good time to get it out of my way. This feature relies on the new Home Manager options list provided by the Elasticsearch backend on top of the existing NixOS one. The primary concern before was unifying the two, but it seems that upstream did it for us :)

I'm keeping this as a draft while @eclairevoyant works on our nix-index replacement. When it's done, I'll introduce a `--db-path` option that can be used to provide a database for offline search and support for other option collections not provided by Elasticsearch. I'm not sure about the specifics *yet*, but it can't be too hard. I'll simply support whatever format our tool provides and expect others to adhere to it. This can be considered as the final blocker for 4.4.0. 

Fixes #85, #126

Eventually could be updated to support #286 through <https://github.com/feel-co/nixdoc>. 



Change-Id: I2e572c26a10f6268bade8117af246bdb6a6a6964

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
