### PR TITLE
nh-clean: delete gcroot source symlinks, not their destinations

### DIFF
--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -38,6 +38,8 @@ static GENERATION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^(.*)-(\d+)-link$").expect("Failed to compile generation regex")
 });
 
+const AUTO_GCROOTS_DIR: &str = "/nix/var/nix/gcroots/auto";
+
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct Generation {
   number:        u32,
@@ -234,17 +236,7 @@ impl args::CleanMode {
           continue;
         }
 
-        let resolved_dst = if dst.is_symlink() {
-          dst.read_link().unwrap_or_else(|_| dst.clone())
-        } else {
-          dst.clone()
-        };
-
-        if !regexes
-          .iter()
-          .any(|next| next.is_match(&dst.to_string_lossy()))
-          && !is_nix_store_direct_child(&resolved_dst)
-        {
+        if !gcroot_matches_filter(&src, &dst, &regexes) {
           debug!("dst doesn't match any gcroot filter, skipping");
           continue;
         }
@@ -585,6 +577,23 @@ fn is_nix_store_direct_child(path: &Path) -> bool {
     .unwrap_or(false)
 }
 
+fn gcroot_matches_filter(src: &Path, dst: &Path, regexes: &[&Regex]) -> bool {
+  let resolved_dst = if dst.is_symlink() {
+    dst.read_link().unwrap_or_else(|_| dst.to_path_buf())
+  } else {
+    dst.to_path_buf()
+  };
+
+  regexes
+    .iter()
+    .any(|next| next.is_match(&dst.to_string_lossy()))
+    || (is_auto_gcroot_entry(src) && is_nix_store_direct_child(&resolved_dst))
+}
+
+fn is_auto_gcroot_entry(path: &Path) -> bool {
+  path.starts_with(AUTO_GCROOTS_DIR)
+}
+
 fn gcroot_path_to_remove(gcroot: &GcRootTagged) -> &Path {
   &gcroot.src
 }
@@ -649,24 +658,54 @@ mod tests {
 
   #[test]
   fn gcroot_filter_passes_direnv_path() {
-    let path = Path::new("/home/user/project/.direnv/something");
+    let src = Path::new("/nix/var/nix/gcroots/project-direnv");
+    let dst = Path::new("/home/user/project/.direnv/something");
     let regexes = [&*DIRENV_REGEX];
-    let passes = regexes
-      .iter()
-      .any(|re| re.is_match(&path.to_string_lossy()))
-      || is_nix_store_direct_child(path);
-    assert!(passes);
+    assert!(gcroot_matches_filter(src, dst, &regexes));
   }
 
   #[test]
-  fn gcroot_filter_passes_store_direct_child() {
-    let path = Path::new("/nix/store/abc123zzz-foo-1.0");
+  fn gcroot_filter_passes_auto_store_direct_child() {
+    let src = Path::new("/nix/var/nix/gcroots/auto/example");
+    let dst = Path::new("/nix/store/abc123zzz-foo-1.0");
     let regexes = [&*DIRENV_REGEX];
-    let passes = regexes
-      .iter()
-      .any(|re| re.is_match(&path.to_string_lossy()))
-      || is_nix_store_direct_child(path);
-    assert!(passes);
+    assert!(gcroot_matches_filter(src, dst, &regexes));
+  }
+
+  #[test]
+  fn gcroot_filter_rejects_non_auto_store_direct_child() {
+    let src = Path::new("/nix/var/nix/gcroots/current-system");
+    let dst = Path::new("/nix/store/abc123zzz-foo-1.0");
+    let regexes = [&*DIRENV_REGEX];
+    assert!(!gcroot_matches_filter(src, dst, &regexes));
+  }
+
+  #[test]
+  fn gcroot_filter_passes_auto_symlink_to_store_direct_child() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let link = dir.path().join("result");
+    std::os::unix::fs::symlink("/nix/store/abc123zzz-foo-1.0", &link)
+      .expect("symlink");
+
+    let src = Path::new("/nix/var/nix/gcroots/auto/example");
+    let regexes = [&*DIRENV_REGEX];
+    assert!(gcroot_matches_filter(src, &link, &regexes));
+  }
+
+  #[test]
+  fn direct_store_filter_is_limited_to_auto_gcroots() {
+    assert!(is_auto_gcroot_entry(Path::new(
+      "/nix/var/nix/gcroots/auto/example"
+    )));
+    assert!(!is_auto_gcroot_entry(Path::new(
+      "/nix/var/nix/gcroots/current-system"
+    )));
+    assert!(!is_auto_gcroot_entry(Path::new(
+      "/nix/var/nix/gcroots/booted-system"
+    )));
+    assert!(!is_auto_gcroot_entry(Path::new(
+      "/nix/var/nix/gcroots/profiles/system"
+    )));
   }
 
   #[test]
@@ -701,13 +740,10 @@ mod tests {
 
   #[test]
   fn gcroot_filter_rejects_arbitrary_path() {
-    let path = Path::new("/home/user/some-random-link");
+    let src = Path::new("/nix/var/nix/gcroots/auto/example");
+    let dst = Path::new("/home/user/some-random-link");
     let regexes = [&*DIRENV_REGEX];
-    let passes = regexes
-      .iter()
-      .any(|re| re.is_match(&path.to_string_lossy()))
-      || is_nix_store_direct_child(path);
-    assert!(!passes);
+    assert!(!gcroot_matches_filter(src, dst, &regexes));
   }
 
   #[test]

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -50,6 +50,13 @@ type ToBeRemoved = bool;
 type GenerationsTagged = BTreeMap<Generation, ToBeRemoved>;
 type ProfilesTagged = HashMap<PathBuf, GenerationsTagged>;
 
+#[derive(Debug)]
+struct GcRootTagged {
+  src: PathBuf,
+  dst: PathBuf,
+  tbr: ToBeRemoved,
+}
+
 /// Filter paths to only include existing directories, logging warnings for
 /// missing ones
 fn filter_existing_dirs<I>(paths: I) -> impl Iterator<Item = PathBuf>
@@ -79,7 +86,7 @@ impl args::CleanMode {
   /// example, if  `User::from_uid(uid)` returns `None`.
   pub fn run(&self, elevate: ElevationStrategy) -> Result<()> {
     let mut profiles = Vec::new();
-    let mut gcroots_tagged: HashMap<PathBuf, ToBeRemoved> = HashMap::new();
+    let mut gcroots_tagged = Vec::new();
     let now = SystemTime::now();
     let mut is_profile_clean = false;
 
@@ -251,11 +258,19 @@ impl args::CleanMode {
           Ok(()) => {
             if dst.metadata().is_err() {
               debug!(?dst, "gcroot target already GC'd, tagging for removal");
-              gcroots_tagged.insert(dst, true);
+              gcroots_tagged.push(GcRootTagged {
+                src,
+                dst,
+                tbr: true,
+              });
             } else if args.keep_one
               && DIRENV_REGEX.is_match(&dst.to_string_lossy())
             {
-              gcroots_tagged.insert(dst, false);
+              gcroots_tagged.push(GcRootTagged {
+                src,
+                dst,
+                tbr: false,
+              });
             } else {
               let dur = now.duration_since(
                 dst
@@ -269,10 +284,18 @@ impl args::CleanMode {
                   warn!(?err, ?now, "Failed to compare time!");
                 },
                 Ok(val) if val <= args.keep_since.into() => {
-                  gcroots_tagged.insert(dst, false);
+                  gcroots_tagged.push(GcRootTagged {
+                    src,
+                    dst,
+                    tbr: false,
+                  });
                 },
                 Ok(_) => {
-                  gcroots_tagged.insert(dst, true);
+                  gcroots_tagged.push(GcRootTagged {
+                    src,
+                    dst,
+                    tbr: true,
+                  });
                 },
               }
             }
@@ -340,18 +363,18 @@ impl args::CleanMode {
         "- {}  /nix/store direct children",
         Paint::new("RE").fg(Color::Magenta)
       );
-      for (path, tbr) in &gcroots_tagged {
-        if *tbr {
+      for gcroot in &gcroots_tagged {
+        if gcroot.tbr {
           println!(
             "- {} {}",
             Paint::new("DEL").fg(Color::Red),
-            path.to_string_lossy()
+            gcroot.dst.to_string_lossy()
           );
         } else {
           println!(
             "- {} {}",
             Paint::new("OK ").fg(Color::Green),
-            path.to_string_lossy()
+            gcroot.dst.to_string_lossy()
           );
         }
       }
@@ -390,9 +413,9 @@ impl args::CleanMode {
     }
 
     if !args.dry {
-      for (path, tbr) in &gcroots_tagged {
-        if *tbr {
-          remove_path_nofail(path);
+      for gcroot in &gcroots_tagged {
+        if gcroot.tbr {
+          remove_path_nofail(gcroot_path_to_remove(gcroot));
         }
       }
 
@@ -562,6 +585,10 @@ fn is_nix_store_direct_child(path: &Path) -> bool {
     .unwrap_or(false)
 }
 
+fn gcroot_path_to_remove(gcroot: &GcRootTagged) -> &Path {
+  &gcroot.src
+}
+
 fn remove_path_nofail(path: &Path) {
   info!("Removing {}", path.to_string_lossy());
   if let Err(err) = std::fs::remove_file(path) {
@@ -640,6 +667,36 @@ mod tests {
       .any(|re| re.is_match(&path.to_string_lossy()))
       || is_nix_store_direct_child(path);
     assert!(passes);
+  }
+
+  #[test]
+  fn gcroot_cleanup_removes_source_not_system_destination() {
+    let gcroot = GcRootTagged {
+      src: PathBuf::from("/nix/var/nix/gcroots/auto/example"),
+      dst: PathBuf::from("/run/current-system"),
+      tbr: true,
+    };
+
+    assert_eq!(
+      gcroot_path_to_remove(&gcroot),
+      Path::new("/nix/var/nix/gcroots/auto/example")
+    );
+    assert_ne!(gcroot_path_to_remove(&gcroot), gcroot.dst.as_path());
+  }
+
+  #[test]
+  fn gcroot_cleanup_removes_source_not_profile_destination() {
+    let gcroot = GcRootTagged {
+      src: PathBuf::from("/nix/var/nix/gcroots/auto/example"),
+      dst: PathBuf::from("/nix/var/nix/profiles/system-2-link"),
+      tbr: true,
+    };
+
+    assert_eq!(
+      gcroot_path_to_remove(&gcroot),
+      Path::new("/nix/var/nix/gcroots/auto/example")
+    );
+    assert_ne!(gcroot_path_to_remove(&gcroot), gcroot.dst.as_path());
   }
 
   #[test]


### PR DESCRIPTION
Hopefully fixes the regression described in #652 

The gcroot loop stored `dst` (the resolved target, e.g. `/run/current-system`) in `gcroots_tagged` and later called `remove_path_nofail(path)` on that key. It should have stored `src` (the gcroot symlink under `/nix/var/nix/gcroots/`) instead. Because the filter in `d1f0818` (`is_nix_store_direct_child`) now accepts symlinks that resolve to direct `/nix/store` children, system/profile symlinks entered the classification path and got marked DEL. Since `dst` was what got removed, critical paths like `/run/current-system` were deleted instead of the gcroot symlink pointing at them.

tl;dr: skill issue

CC @faukah oh whether we should maintain a list of critical paths that trigger a "Are you sure you want to do this?" prompt similar to `--ask` even when `--ask` is not provided. I'd probably make this overridable with either an env var taking a regex (so user can extend or empty the list) or a bool.

Change-Id: I6b3261fc0f38430274f776d47e22edd06a6a6964
