### PR TITLE
nh-nixos: add delete subcommand to remove and gc specific generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ functionality, under the "Removed" section.
   `/nix/var/nix/gcroots`.
 - `--no-direnv` passed to `nh clean all` will now preserve `.direnv/` paths as
   well.
+- `nh os delete` deletes specific generations by generation ID. Runs
+  `nix-store gc` and `switch-to-configuration boot` by default after the
+  generations are removed.
 
 ### Changed
 

--- a/crates/nh-nixos/src/args.rs
+++ b/crates/nh-nixos/src/args.rs
@@ -329,6 +329,10 @@ pub struct OsDeleteArgs {
   #[arg(long, short)]
   pub ask: bool,
 
+  /// Don't run nix store --gc
+  #[arg(long = "no-gc", alias = "nogc")]
+  pub no_gc: bool,
+
   /// Don't panic if calling nh as root
   #[arg(short = 'R', long, env = "NH_BYPASS_ROOT_CHECK")]
   pub bypass_root_check: bool,

--- a/crates/nh-nixos/src/args.rs
+++ b/crates/nh-nixos/src/args.rs
@@ -70,9 +70,9 @@ impl OsArgs {
           Box::new(LegacyFeatures)
         }
       },
-      OsSubcommand::Info(_) | OsSubcommand::Rollback(_) => {
-        Box::new(LegacyFeatures)
-      },
+      OsSubcommand::Info(_)
+      | OsSubcommand::Rollback(_)
+      | OsSubcommand::Delete(_) => Box::new(LegacyFeatures),
 
       OsSubcommand::BuildImage(args) => {
         if args.common.uses_flakes() {
@@ -107,6 +107,9 @@ pub enum OsSubcommand {
 
   /// Rollback to a previous generation
   Rollback(OsRollbackArgs),
+
+  /// Delete specific generations from profile path
+  Delete(OsDeleteArgs),
 
   /// Build a `NixOS` VM image
   BuildVm(OsBuildVmArgs),
@@ -306,4 +309,27 @@ pub struct OsGenerationsArgs {
   /// Comma-delimited list of field(s) to display
   #[arg(long, value_delimiter = ',')]
   pub fields: Option<Vec<Field>>,
+}
+
+#[derive(Debug, Args)]
+pub struct OsDeleteArgs {
+  /// Generations to delete. Run 'nh os info' to list available IDs.
+  #[arg(required = true)]
+  pub generations: Vec<u64>,
+
+  /// Path to Nix' profiles directory
+  #[arg(long, short = 'P', default_value = "/nix/var/nix/profiles/system")]
+  pub profile: Option<String>,
+
+  /// Only print actions, without performing them
+  #[arg(long, short = 'n')]
+  pub dry: bool,
+
+  /// Ask for confirmation
+  #[arg(long, short)]
+  pub ask: bool,
+
+  /// Don't panic if calling nh as root
+  #[arg(short = 'R', long, env = "NH_BYPASS_ROOT_CHECK")]
+  pub bypass_root_check: bool,
 }

--- a/crates/nh-nixos/src/args.rs
+++ b/crates/nh-nixos/src/args.rs
@@ -333,6 +333,10 @@ pub struct OsDeleteArgs {
   #[arg(long = "no-gc", alias = "nogc")]
   pub no_gc: bool,
 
+  /// Don't update the bootloader menu
+  #[arg(long = "no-boot", alias = "noboot")]
+  pub no_boot: bool,
+
   /// Don't panic if calling nh as root
   #[arg(short = 'R', long, env = "NH_BYPASS_ROOT_CHECK")]
   pub bypass_root_check: bool,

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -26,6 +26,7 @@ use crate::{
     self,
     OsBuildImageArgs,
     OsBuildVmArgs,
+    OsDeleteArgs,
     OsGenerationsArgs,
     OsRebuildActivateArgs,
     OsRebuildArgs,
@@ -93,6 +94,7 @@ impl args::OsArgs {
       OsSubcommand::Repl(args) => args.run(),
       OsSubcommand::Info(args) => args.info(),
       OsSubcommand::Rollback(args) => args.rollback(elevation),
+      OsSubcommand::Delete(args) => args.delete(elevation),
       OsSubcommand::BuildImage(args) => args.build_image(&elevation),
     }
   }
@@ -1431,6 +1433,128 @@ impl OsGenerationsArgs {
 
     generations::print_info(descriptions, self.fields.as_deref())?;
 
+    Ok(())
+  }
+}
+
+impl OsDeleteArgs {
+  fn delete(&self, elevation: ElevationStrategy) -> Result<()> {
+    let elevate = has_elevation_status(self.bypass_root_check, &elevation)?;
+
+    let profile = match self.profile {
+      Some(ref p) => PathBuf::from(p),
+      None => bail!("Profile path is required"),
+    };
+
+    if !profile.is_symlink() {
+      return Err(eyre!(
+        "No profile `{:?}` found",
+        profile.file_name().unwrap_or_default()
+      ));
+    }
+
+    // Determine the current generation of the profile
+    let current_generation_link = fs::read_link(&profile).wrap_err(
+      "Failed to read profile symlink to determine current generation",
+    )?;
+
+    let current_gen_num = generations::from_dir(&current_generation_link)
+      .ok_or_else(|| eyre!("Failed to parse current generation number"))?;
+
+    // Find the profile directory and the base name of the profile (e.g.
+    // "system")
+    let profile_dir = profile.parent().unwrap_or_else(|| Path::new("."));
+    let profile_name = profile
+      .file_name()
+      .and_then(|n| n.to_str())
+      .ok_or_else(|| eyre!("Invalid profile name"))?;
+
+    // Gather existing generations
+    let mut existing_gens = std::collections::HashMap::new();
+    for entry in fs::read_dir(profile_dir)? {
+      let entry = entry?;
+      let path = entry.path();
+      if let Some(name) = path.file_name().and_then(|s| s.to_str())
+        && name.starts_with(&format!("{profile_name}-"))
+        && name.ends_with("-link")
+        && let Some(num) = generations::from_dir(&path)
+      {
+        existing_gens.insert(num, path);
+      }
+    }
+
+    // Deduplicate and validate targets
+    let mut targets = self.generations.clone();
+    targets.sort_unstable();
+    targets.dedup();
+
+    let mut paths_to_delete = Vec::new();
+    for generation_num in &targets {
+      if *generation_num == current_gen_num {
+        bail!("Cannot delete the current generation ({})", generation_num);
+      }
+      if let Some(path) = existing_gens.get(generation_num) {
+        paths_to_delete.push((*generation_num, path.clone()));
+      } else {
+        bail!(
+          "Generation {} does not exist for profile {:?}",
+          generation_num,
+          profile_name
+        );
+      }
+    }
+
+    // Confirmation / Dry-run
+    if self.dry {
+      info!("Dry run: would delete the following generation(s):");
+      for (generation_num, _) in &paths_to_delete {
+        info!("  - Generation {}", generation_num);
+      }
+      return Ok(());
+    }
+
+    if self.ask {
+      let confirmation =
+        inquire::Confirm::new(&format!("Delete generation(s) {targets:?}?"))
+          .with_default(false)
+          .prompt()?;
+
+      if !confirmation {
+        bail!("User rejected the deletion");
+      }
+    }
+
+    info!("Deleting generation(s)...");
+    for (generation_num, path) in &paths_to_delete {
+      Command::new("rm")
+        .arg(path)
+        .elevate(elevate.then_some(elevation.clone()))
+        .message(format!(
+          "Removing generation link {} (generation {})",
+          path.display(),
+          generation_num
+        ))
+        .with_required_env()
+        .run()
+        .wrap_err_with(|| {
+          format!("Failed to remove generation link {}", path.display())
+        })?;
+    }
+
+    // Run bootloader activation hook if it exists
+    let switch_to_configuration =
+      Path::new("/run/current-system/bin/switch-to-configuration");
+    if switch_to_configuration.exists() {
+      Command::new(switch_to_configuration)
+        .arg("boot")
+        .elevate(elevate.then_some(elevation))
+        .message("Updating bootloader entries")
+        .with_required_env()
+        .run()
+        .wrap_err("Failed to update bootloader after deleting generations")?;
+    }
+
+    info!("Generation(s) deleted successfully.");
     Ok(())
   }
 }

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -1554,6 +1554,16 @@ impl OsDeleteArgs {
         .wrap_err("Failed to update bootloader after deleting generations")?;
     }
 
+    if !self.no_gc {
+      Command::new("nix")
+        .args(["store", "gc"])
+        .dry(self.dry)
+        .message("Performing garbage collection on the nix store")
+        .show_output(true)
+        .with_required_env()
+        .run()?;
+    }
+
     info!("Generation(s) deleted successfully.");
     Ok(())
   }

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -1544,7 +1544,7 @@ impl OsDeleteArgs {
     // Run bootloader activation hook if it exists
     let switch_to_configuration =
       Path::new("/run/current-system/bin/switch-to-configuration");
-    if switch_to_configuration.exists() {
+    if !self.no_boot && switch_to_configuration.exists() {
       Command::new(switch_to_configuration)
         .arg("boot")
         .elevate(elevate.then_some(elevation))


### PR DESCRIPTION
This pull request introduces a `delete` subcommand to `nh os` allowing users to delete and garbage collect specific system generations.

### Examples Usages
- `nh os delete 80`
- `nh os delete 91 92`

The generation IDs can be obtained from `nh os info`. 

By default, it will also run `nix store gc` and `switch-to-configuration boot` to remove the boot menu of the pruned generations. These can be controlled with `no-gc` and `no-boot`.

I'm a new user of  `nh` and in my workflow I sometimes prefer to prune specific generations rather than everything older than a timestamp, so I decided to try adding support for it to `nh`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

## AI Disclosure

Per the [AI Policy](https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md#ai-policy), I'm disclosing that this feature was implemented with the assistance of Antigravity CLI. With that said, I've:
- reviewed the code thoroughly
- tried to ensure that it's following coding patterns and paradigms consistent with the project
- tested locally on my own system

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
