### PR TITLE
maintenance

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -60,9 +60,6 @@ jobs:
           - platform: aarch64-linux
             runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - platform: x86_64-darwin
-            runner: macos-latest
-            target: x86_64-apple-darwin
           - platform: aarch64-darwin
             runner: macos-14
             target: aarch64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ functionality, under the "Removed" section.
 
 ### Removed
 
+- `nh` no longer supports `x86_64-darwin`, following Nixpkgs' decision 
+   to drop support for that platform.
+
 ## 4.3.2
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,13 +130,9 @@ NH:
 
 - `x86_64-linux`
 - `aarch64-linux`
-- `x86_64-darwin`
 - `aarch64-darwin`
 
-Please try to test on _at least_ `x86_64-linux` and `aarch64-darwin`. The
-`x86_64-darwin` target is set to be phased out with the 26.05 release, as
-Nixpkgs aims to drop it. We may try to support it as long as we can if a Darwin
-maintainer joins the NH team.
+Please try to test on _at least_ `x86_64-linux` and `aarch64-darwin`.
 
 ## Submitting Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ dependencies = [
  "semver",
  "serde_json",
  "serial_test",
- "shlex 1.3.0",
+ "shlex",
  "subprocess",
  "system-configuration",
  "tempfile",
@@ -1453,7 +1453,7 @@ dependencies = [
  "proptest",
  "secrecy",
  "serial_test",
- "shlex 1.3.0",
+ "shlex",
  "signal-hook 0.4.4",
  "subprocess",
  "tracing",
@@ -2219,12 +2219,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru-slab"
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2718,9 +2718,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ semver = "1.0.27"
 serde = { features = [ "derive" ], version = "1.0.228" }
 serde_json = "1.0.145"
 serial_test = "3.2.0"
-shlex = "1.3.0"
+shlex = "2.0.1"
 signal-hook = "0.4.1"
 spam-db = "0.1.0"
 subprocess = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition      = "2024"
 license      = "EUPL-1.2"
-rust-version = "1.91.1"
+rust-version = "1.95.0"
 version      = "4.4.0-beta1"
 
 [workspace.dependencies]

--- a/crates/nh-search/src/channel.rs
+++ b/crates/nh-search/src/channel.rs
@@ -6,8 +6,13 @@ use tracing::warn;
 
 // List of deprecated NixOS versions.
 // Add new versions as they become deprecated.
-const DEPRECATED_VERSIONS: &[&str] =
-  &["nixos-23.11", "nixos-24.05", "nixos-24.11", "nixos-25.05"];
+const DEPRECATED_VERSIONS: &[&str] = &[
+  "nixos-23.11",
+  "nixos-24.05",
+  "nixos-24.11",
+  "nixos-25.05",
+  "nixos-25.11",
+];
 
 static SUPPORTED_BRANCH_REGEX: OnceLock<Regex> = OnceLock::new();
 
@@ -62,11 +67,12 @@ fn supported_branch<S: AsRef<str>>(branch: S) -> bool {
 #[test]
 fn test_supported_branch() {
   assert!(supported_branch("nixos-unstable"));
-  assert!(supported_branch("nixos-25.11"));
+  assert!(supported_branch("nixos-26.05"));
   assert!(!supported_branch("nixos-unstable-small"));
   assert!(!supported_branch("nixos-24.05"));
   assert!(!supported_branch("nixos-24.11"));
   assert!(!supported_branch("nixos-25.05"));
+  assert!(!supported_branch("nixos-25.11"));
   assert!(!supported_branch("24.05"));
   assert!(!supported_branch("nixpkgs-darwin"));
   assert!(!supported_branch("nixpks-21.11-darwin"));

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
         nixpkgs.lib.genAttrs [
           "x86_64-linux"
           "aarch64-linux"
-          "x86_64-darwin"
           "aarch64-darwin"
         ] (system: function nixpkgs.legacyPackages.${system});
 
@@ -26,7 +25,7 @@
         default = self.packages.${pkgs.stdenv.hostPlatform.system}.nh;
       });
 
-      checks = builtins.removeAttrs (self.packages // self.devShells) [ "x86_64-darwin" ];
+      checks = self.packages // self.devShells;
 
       devShells = forAllSystems (pkgs: {
         default = import ./shell.nix { inherit pkgs; };


### PR DESCRIPTION
- bump the MSRV to 1.95
- update all cargo inputs,
- drop `x86_64-darwin`
- update the deprecated nixpkgs versions.  

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
