### PR TITLE
tests: fix `test_get_build_image_variants_flake` on macOS

### DIFF
--- a/crates/nh-core/src/util.rs
+++ b/crates/nh-core/src/util.rs
@@ -612,9 +612,14 @@ mod tests {
     let test_dir = tempfile::Builder::new()
       .prefix("nh-test")
       .tempdir()
-      .expect("Failed to create temp file");
+      .expect("Failed to create temp dir");
 
-    let test_file = test_dir.path().join("flake.nix");
+    // Canonicalize to resolve symlinks
+    let canonical = test_dir
+      .path()
+      .canonicalize()
+      .expect("Failed to canonicalize temp dir");
+    let test_file = canonical.join("flake.nix");
     let test_content = r"
 {
   outputs = _: {
@@ -629,7 +634,7 @@ mod tests {
     fs::write(&test_file, test_content).expect("Failed to write test file");
 
     let installable = Installable::Flake {
-      reference: format!("path:{}", test_dir.path().display()),
+      reference: format!("path:{}", canonical.display()),
       attribute: vec![
         "nixosConfigurations".to_owned(),
         "test".to_string(),


### PR DESCRIPTION
On macOS, `TMPDIR` points through symlinks (`/var` -> `/private/var`,
`/tmp` -> `/private/tmp`) and nix eval refuses `path:` references containing
symlinked components.

This commit canonicalizes the temp dir path before constructing the flake
reference.

## Sanity Checking


[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
