### PR TITLE
flake: build for all nixpkgs systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,21 @@
       nixpkgs,
     }:
     let
-      forAllSystems =
-        function:
-        nixpkgs.lib.genAttrs [
-          "x86_64-linux"
-          "aarch64-linux"
-          "aarch64-darwin"
-        ] (system: function nixpkgs.legacyPackages.${system});
+      inherit (nixpkgs) lib;
+
+      pkgsFor = system: nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
+
+      supportedSystems = builtins.filter (
+        system: (builtins.tryEval (pkgsFor system).stdenv.hostPlatform).success
+      ) (lib.systems.doubles.linux ++ lib.systems.doubles.darwin);
+
+      forAllSystems = function: lib.genAttrs supportedSystems (system: function (pkgsFor system));
+
+      ciSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
       rev = self.shortRev or self.dirtyShortRev or "dirty";
     in
@@ -25,7 +33,7 @@
         default = self.packages.${pkgs.stdenv.hostPlatform.system}.nh;
       });
 
-      checks = self.packages // self.devShells;
+      checks = lib.genAttrs ciSystems (system: self.packages.${system});
 
       devShells = forAllSystems (pkgs: {
         default = import ./shell.nix { inherit pkgs; };


### PR DESCRIPTION
This enables users to build this package on any platform, such as `powerpc64-linux`. Unfortunately I'm still blocked on nom not playing nicely with other architectures due to it being in Haskell, but this does work without nom.

## Sanity Checking

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
  - [x] `powerpc64-linux` 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
On macOS, `TMPDIR` points through symlinks (`/var` -> `/private/var`,
`/tmp` -> `/private/tmp`) and nix eval refuses `path:` references containing
symlinked components.

This commit canonicalizes the temp dir path before constructing the flake
reference.