### PR TITLE
Add docstring to args module for improved readability

### DIFF
--- a/crates/nh-nixos/src/lib.rs
+++ b/crates/nh-nixos/src/lib.rs
@@ -1,3 +1,4 @@
+/// Module for handling command-line arguments.
 pub mod args;
 pub mod generations;
 pub mod nixos;


### PR DESCRIPTION
## Background
The `args` module in `crates/nh-nixos/src/lib.rs` lacked documentation, which could hinder code readability and maintainability for contributors and users.

## Changes
Added a docstring to the `args` module to describe its purpose: handling command-line arguments. This is a minimal, style-consistent update that does not alter any functionality.

## Verification
- The change was verified by ensuring the code compiles without errors (`cargo build`).
- Documentation can be generated and checked using `cargo doc` to confirm the new docstring appears correctly.
- No tests are affected as this is a documentation-only modification.