### PR TITLE
nh-core: use late pty allocation for run0 elevation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- Local `run0` elevation now uses `--pty-late`, avoiding terminal ownership
+  changes can break subsequent commands.
 - `nh os switch --target-host root@host` no longer wraps the activation in
   `sudo --prompt= --stdin` when the SSH user is already uid 0. The elevation
   decision now probes `id -u` over the established ControlMaster instead of

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -613,6 +613,13 @@ impl Command {
     {
       cmd = cmd.env("SUDO_ASKPASS", askpass).arg("-A");
     }
+    // Request allocation of a pseudo TTY for the run0 session. Without this,
+    // running `run0` changes the user of `/dev/pts/<current-terminal>
+    // to `root`, which we want to avoid since it can cause issues with
+    // subsequent commands.
+    if program_name == "run0" {
+      cmd = cmd.arg("--pty-late");
+    }
 
     // NH_PRESERVE_ENV: set to "0" to disable preserving environment variables,
     // "1" to force, unset defaults to force
@@ -660,6 +667,13 @@ impl Command {
       && let Ok(_askpass) = std::env::var("NH_SUDO_ASKPASS")
     {
       parts.push("-A".to_string());
+    }
+    // Request allocation of a pseudo TTY for the run0 session. Without this,
+    // running `run0` changes the user of `/dev/pts/<current-terminal>
+    // to `root`, which we want to avoid since it can cause issues with
+    // subsequent commands.
+    if program_name == "run0" {
+      parts.push("--pty-late".to_string());
     }
 
     let preserve_env = std::env::var("NH_PRESERVE_ENV")


### PR DESCRIPTION
closes #641.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
