### PR TITLE
nh-core: mark installable as path in nushell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ functionality, under the "Removed" section.
 
 - Local `run0` elevation now uses `--pty-late`, avoiding terminal ownership
   changes can break subsequent commands.
+- Generated Nushell completions now mark the `installable` argument as a path
+  while keeping nh's own parser compatible with flake references.
 - `nh os switch --target-host root@host` no longer wraps the activation in
   `sudo --prompt= --stdin` when the SSH user is already uid 0. The elevation
   decision now probes `id -u` over the established ControlMaster instead of

--- a/crates/nh-core/src/installable.rs
+++ b/crates/nh-core/src/installable.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-use clap::{Arg, ArgAction, Args, FromArgMatches, error::ErrorKind};
+use clap::{Arg, ArgAction, Args, FromArgMatches, ValueHint, error::ErrorKind};
 use tracing::debug;
 use yansi::{Color, Paint};
 
@@ -128,6 +128,7 @@ impl Args for Installable {
       .arg(
         Arg::new("installable")
           .action(ArgAction::Set)
+          .value_hint(ValueHint::AnyPath)
           .value_name("INSTALLABLE")
           .help("Which installable to use")
           .long_help(format!(
@@ -395,6 +396,17 @@ where
 fn test_join_attribute() {
   assert_eq!(join_attribute(vec!["foo", "bar"]), "foo.bar");
   assert_eq!(join_attribute(vec!["foo", "bar.baz"]), r#"foo."bar.baz""#);
+}
+
+#[test]
+fn installable_arg_is_path_hinted_for_completions() {
+  let cmd = Installable::augment_args(clap::Command::new("nh"));
+  let installable_arg = cmd
+    .get_arguments()
+    .find(|arg| arg.get_id().as_str() == "installable")
+    .expect("installable arg should exist");
+
+  assert_eq!(installable_arg.get_value_hint(), ValueHint::AnyPath);
 }
 
 enum FallbackError {


### PR DESCRIPTION
*hopefully* fixes #584 once and for all. 

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
