### PR TITLE
treewide: pass no-write-lock-file to nix flake update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `--no-write-lock-file` is now also passed to `nix flake update` when using
+  `--update` or `--update-input`.
 - `nh os switch --target-host root@host` no longer wraps the activation in
   `sudo --prompt= --stdin` when the SSH user is already uid 0. The elevation
   decision now probes `id -u` over the established ControlMaster instead of

--- a/crates/nh-core/src/update.rs
+++ b/crates/nh-core/src/update.rs
@@ -19,6 +19,7 @@ pub fn update(
   installable: &Installable,
   inputs: Option<Vec<String>>,
   commit_lock_file: bool,
+  no_write_lock_file: bool,
 ) -> Result<()> {
   let Installable::Flake { reference, .. } = installable else {
     warn!(
@@ -32,6 +33,9 @@ pub fn update(
 
   if commit_lock_file {
     cmd = cmd.arg("--commit-lock-file");
+  }
+  if no_write_lock_file {
+    cmd = cmd.arg("--no-write-lock-file");
   }
 
   if let Some(inputs) = inputs {

--- a/crates/nh-darwin/src/darwin.rs
+++ b/crates/nh-darwin/src/darwin.rs
@@ -102,6 +102,7 @@ impl DarwinRebuildArgs {
         &installable,
         self.update_args.update_input,
         self.common.passthrough.commit_lock_file,
+        self.common.passthrough.no_write_lock_file,
       )?;
     }
 

--- a/crates/nh-home/src/home.rs
+++ b/crates/nh-home/src/home.rs
@@ -86,6 +86,7 @@ impl HomeRebuildArgs {
         &installable,
         self.update_args.update_input,
         self.common.passthrough.commit_lock_file,
+        self.common.passthrough.no_write_lock_file,
       )?;
     }
 

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -175,6 +175,7 @@ impl OsRebuildActivateArgs {
         &toplevel,
         self.rebuild.update_args.update_input.clone(),
         self.rebuild.common.passthrough.commit_lock_file,
+        self.rebuild.common.passthrough.no_write_lock_file,
       )?;
     }
 
@@ -726,6 +727,7 @@ impl OsRebuildArgs {
         &toplevel,
         self.update_args.update_input.clone(),
         self.common.passthrough.commit_lock_file,
+        self.common.passthrough.no_write_lock_file,
       )?;
     }
 


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
