### PR TITLE
docs: document NH_FILE and NH_ATTRP env vars

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -348,6 +348,11 @@ example, if `NH_FLAKE` or `NH_OS_FLAKE` is set you may simply run `nh os switch`
 with no additional arguments, and it will automatically resolve
 `nixosConfigurations.<myHost>`.
 
+Additionally, NH also allows omitting the path to your non-flake nix config.
+You can specify the Nix file and Nix attribute path with the `NH_FILE` and
+`NH_ATTRP` environment variables. If `NH_FILE` and `NH_ATTRP` are both set,
+`nh os switch` effectively evaluates `$NH_FILE#$NH_ATTRP`.
+
 ## Environment variables
 
 NH supports several environment variables to control command behaviour. Some of

--- a/xtask/src/man.rs
+++ b/xtask/src/man.rs
@@ -76,6 +76,16 @@ pub fn generate(out_dir: &str) -> Result<(), String> {
        precedence over NH_FLAKE.",
     ),
     (
+      "NH_FILE",
+      "Preferred path to a directory/file containing a Nix expression. Chosen \
+       after os/home/darwin-specific env vars, but before NH_FLAKE.",
+    ),
+    (
+      "NH_ATTRP",
+      "Nix attribute path for an expression specified with NH_FILE. For \
+       example, nixosConfigurations.<hostname>.",
+    ),
+    (
       "NH_SUDO_ASKPASS",
       "Path to a program used as SUDO_ASKPASS when NH self-elevates with sudo.",
     ),


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---
---

Putting this up because I recently switched from using a flake based config to a non-flake config. I had been running `nh os switch --file . nixosConfigurations.<hostname>` from my local clone of my nix config repo, but also saw these two vars in the codebase. 

These two vars were not previously documented in the README at `docs/README.md` or the man-page at `xtasks/src/man.rs`, but they are entirely functional, similar to `NH_FLAKE`, implemented in `crates/nh-core/src/installable.rs`. So, I am simply documenting them so others feel confident using them in their nix/nixos configs.

After [these changes in my config](https://github.com/tfrancisl/nixos-config/commit/236b6ca6845126ef1e76a8eea7f8c1ec56117a8e), I can run `nh os switch` from anywhere on nixos to switch, so these vars definitely work as expected. I'll test this on darwin as well but I suspect the results will be the same.