### PR TITLE
nh-search: reword auth prompt message. 

### DIFF
--- a/crates/nh-search/src/github/auth.rs
+++ b/crates/nh-search/src/github/auth.rs
@@ -11,6 +11,7 @@ use color_eyre::{
   eyre::{Context, bail},
 };
 use secrecy::{ExposeSecret, SecretString};
+use yansi::Paint;
 
 const TOKEN_CREATION_URL: &str =
   "https://github.com/settings/personal-access-tokens/new";
@@ -42,16 +43,14 @@ pub fn token() -> Result<SecretString> {
   }
 
   eprintln!(
-    "Create a GitHub token at {TOKEN_CREATION_URL} if you do not already have \
-     one."
-  );
-  eprintln!(
-    "No token scopes are needed; NH only uses it so GitHub treats requests as \
-     authenticated."
-  );
-  eprintln!(
-    "The token will be saved at {} with user-only permissions.",
-    token_path.display()
+    r"NH needs a GitHub token to access the GitHub API for searching pull requests and issues.
+Please create a GitHub token at {}
+if you do not already have one, or paste an existing token down below.
+You do not need to set any scopes for your token since NH only uses it to make authenticated requests to GitHub.
+The token will be saved to {} with user-only permissions.
+     ",
+    TOKEN_CREATION_URL.underline().blue(),
+    token_path.display().green()
   );
 
   let token = inquire::Password::new("GitHub token:")


### PR DESCRIPTION
depends on #689, is stacked on top of that.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
