### PR TITLE
nh-search: drop regex from supported_branch

### DIFF
--- a/crates/nh-search/src/channel.rs
+++ b/crates/nh-search/src/channel.rs
@@ -1,7 +1,4 @@
-use std::sync::OnceLock;
-
 use color_eyre::{Result, eyre::bail};
-use regex::Regex;
 use tracing::warn;
 
 // List of deprecated NixOS versions.
@@ -13,8 +10,6 @@ const DEPRECATED_VERSIONS: &[&str] = &[
   "nixos-25.05",
   "nixos-25.11",
 ];
-
-static SUPPORTED_BRANCH_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Validates the channel, applying fallback for deprecated versions.
 ///
@@ -54,14 +49,15 @@ fn supported_branch<S: AsRef<str>>(branch: S) -> bool {
     return false;
   }
 
-  let re = SUPPORTED_BRANCH_REGEX.get_or_init(|| {
-    Regex::new(r"^nixos-\d+\.\d+$").unwrap_or_else(|e| {
-      warn!("invalid regex in supported_branch: {e}");
-      #[allow(clippy::expect_used)]
-      Regex::new("$^").expect("Regex $^ should always be valid")
+  branch
+    .strip_prefix("nixos-")
+    .and_then(|version| version.split_once('.'))
+    .is_some_and(|(major, minor)| {
+      !major.is_empty()
+        && !minor.is_empty()
+        && major.bytes().all(|byte| byte.is_ascii_digit())
+        && minor.bytes().all(|byte| byte.is_ascii_digit())
     })
-  });
-  re.is_match(branch)
 }
 
 #[test]
@@ -74,6 +70,10 @@ fn test_supported_branch() {
   assert!(!supported_branch("nixos-25.05"));
   assert!(!supported_branch("nixos-25.11"));
   assert!(!supported_branch("24.05"));
+  assert!(!supported_branch("nixos-26"));
+  assert!(!supported_branch("nixos-.05"));
+  assert!(!supported_branch("nixos-26."));
+  assert!(!supported_branch("nixos-26.05.1"));
   assert!(!supported_branch("nixpkgs-darwin"));
   assert!(!supported_branch("nixpks-21.11-darwin"));
 }


### PR DESCRIPTION
Simpler, stdlib instead of an external crate. 

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [X] I have read and understood the [contribution guidelines]
- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [X] I ran **`cargo fmt`** to format my Rust code
  - [X] I have added appropriate documentation to new code
  - [X] My changes are consistent with the rest of the codebase
- Correctness
  - [X] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [X] My code includes comments in particularly complex areas to explain the
        logic
  - [X] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
