### PR TITLE
treewide: defer Nix command execution to `nix-command` builder API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -553,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1332,6 +1332,7 @@ dependencies = [
  "inquire",
  "nh-installable",
  "nix",
+ "nix-command",
  "proptest",
  "regex",
  "secrecy",
@@ -1434,6 +1435,7 @@ dependencies = [
  "elasticsearch-dsl",
  "indicatif",
  "inquire",
+ "nix-command",
  "regex",
  "reqwest",
  "secrecy",
@@ -1462,12 +1464,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix-command"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b65669c8d09c13f09c21720e44693deee136c621063c106fdd3340d5473438c"
+dependencies = [
+ "subprocess",
+ "thiserror",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1903,7 +1915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1960,7 +1972,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2233,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2353,7 +2365,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2363,7 +2375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2890,7 +2902,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ elasticsearch-dsl     = "0.4.24"
 humantime             = "2.3.0"
 indicatif             = "0.18.4"
 inquire               = { default-features = false, features = [ "crossterm" ], version = "0.9.1" }
+nix-command           = "0.2.3"
 
 nix = { default-features = false, features = [ "fs", "user", "hostname" ], version = "0.31.1" }
 proptest = "1.9.0"

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -13,7 +13,7 @@ use color_eyre::{
   eyre::{Context, ContextCompat, bail, eyre},
 };
 use inquire::Confirm;
-use nh_core::command::{Command, ElevationStrategy};
+use nh_core::command::{Command, CommandKind, ElevationStrategy, NixCommand};
 use nix::{
   errno::Errno,
   fcntl::AtFlags,
@@ -428,12 +428,12 @@ impl args::CleanMode {
     }
 
     if !args.no_gc {
-      let mut gc_args = vec!["store", "gc"];
+      let mut gc_args = vec!["gc"];
       if let Some(ref max) = args.max {
         gc_args.push("--max");
         gc_args.push(max.as_str());
       }
-      Command::new("nix")
+      Command::nix(CommandKind::Store)
         .args(gc_args)
         .dry(args.dry)
         .message("Performing garbage collection on the nix store")
@@ -443,7 +443,7 @@ impl args::CleanMode {
     }
 
     if args.optimise {
-      Command::new("nix-store")
+      Command::from_nix_command(NixCommand::nix_store())
         .args(["--optimise"])
         .dry(args.dry)
         .message("Optimising the nix store")

--- a/crates/nh-core/Cargo.toml
+++ b/crates/nh-core/Cargo.toml
@@ -12,6 +12,7 @@ color-eyre.workspace     = true
 dix.workspace            = true
 inquire.workspace        = true
 nh-installable.workspace = true
+nix-command.workspace    = true
 nix.workspace            = true
 regex.workspace          = true
 secrecy.workspace        = true

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -13,6 +13,7 @@ use color_eyre::{
   eyre::{self, Context, bail},
 };
 use nh_installable::Installable;
+pub use nix_command::{CommandKind, NixCommand};
 use secrecy::{ExposeSecret, SecretString};
 use subprocess::{Exec, ExitStatus, Redirection};
 use thiserror::Error;
@@ -400,6 +401,25 @@ impl Command {
       show_output: false,
       env_vars:    HashMap::new(),
     }
+  }
+
+  #[must_use]
+  pub fn from_nix_command(nix_command: NixCommand) -> Self {
+    let (command, args, env) = nix_command.into_parts();
+    let mut cmd = Self::new(command);
+    cmd.args = args;
+    for (key, value) in env {
+      cmd.env_vars.insert(
+        key.to_string_lossy().into_owned(),
+        EnvAction::Set(value.to_string_lossy().into_owned()),
+      );
+    }
+    cmd
+  }
+
+  #[must_use]
+  pub fn nix(kind: CommandKind) -> Self {
+    Self::from_nix_command(NixCommand::new(kind))
   }
 
   /// Set whether to run the command with elevated privileges.
@@ -980,10 +1000,12 @@ impl Build {
 
     let installable_args = self.installable.to_args();
 
-    let base_command = Exec::cmd("nix")
-      .arg("build")
+    let base_command = NixCommand::new(CommandKind::Build)
+      .print_build_logs(false)
       .args(&installable_args)
-      .args(&self.extra_args);
+      .args(&self.extra_args)
+      .with_required_env()
+      .to_exec();
 
     if self.nom {
       let pipeline = {

--- a/crates/nh-core/src/update.rs
+++ b/crates/nh-core/src/update.rs
@@ -3,7 +3,7 @@ use color_eyre::Result;
 use nh_installable::Installable;
 use tracing::warn;
 
-use crate::command::Command;
+use crate::command::{Command, CommandKind};
 
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
@@ -34,7 +34,7 @@ pub fn update(
     return Ok(());
   };
 
-  let mut cmd = Command::new("nix").args(["flake", "update"]);
+  let mut cmd = Command::nix(CommandKind::Flake).arg("update");
 
   if commit_lock_file {
     cmd = cmd.arg("--commit-lock-file");

--- a/crates/nh-core/src/util.rs
+++ b/crates/nh-core/src/util.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use tracing::{debug, info, warn};
 use yansi::Paint;
 
-use crate::command::{Command, ElevationStrategy};
+use crate::command::{Command, CommandKind, ElevationStrategy, NixCommand};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NixVariant {
@@ -34,8 +34,7 @@ static NIX_EXPERIMENTAL_FEATURES: OnceLock<HashSet<String>> = OnceLock::new();
 fn get_nix_version_output() -> Option<&'static String> {
   NIX_VERSION_OUTPUT
     .get_or_init(|| {
-      Command::new("nix")
-        .arg("--version")
+      Command::from_nix_command(NixCommand::raw().arg("--version"))
         .run_capture()
         .ok()
         .flatten()
@@ -308,8 +307,8 @@ pub fn get_nix_experimental_features() -> Result<HashSet<String>> {
   }
 
   // Not cached, fetch them
-  let output = Command::new("nix")
-    .args(["config", "show", "experimental-features"])
+  let output = Command::nix(CommandKind::Config)
+    .args(["show", "experimental-features"])
     .run_capture()?;
 
   // If running with dry=true, output might be None
@@ -435,7 +434,7 @@ in
     },
   };
 
-  let result = Command::new("nix-instantiate")
+  let result = Command::from_nix_command(NixCommand::nix_instantiate())
     .arg("--eval")
     .arg("--strict")
     .arg("--json")
@@ -472,8 +471,7 @@ in
 pub fn get_build_image_variants_flake(
   installable: &nh_installable::Installable,
 ) -> Result<Vec<String>> {
-  let result = Command::new("nix")
-    .arg("eval")
+  let result = Command::nix(CommandKind::Eval)
     .arg("--json")
     .args(installable.to_args())
     .arg("--apply")

--- a/crates/nh-darwin/src/darwin.rs
+++ b/crates/nh-darwin/src/darwin.rs
@@ -9,7 +9,7 @@ use color_eyre::{
 };
 use nh_core::{
   args::DiffType,
-  command::{Command, ElevationStrategy},
+  command::{Command, CommandKind, ElevationStrategy, NixCommand},
   update::update,
   util::{get_hostname, print_dix_diff},
 };
@@ -174,14 +174,16 @@ impl DarwinRebuildArgs {
     }
 
     if matches!(variant, Switch) {
-      Command::new("nix")
-        .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
-        .arg(&out_path)
-        .elevate(Some(elevation.clone()))
-        .dry(self.common.dry)
-        .with_required_env()
-        .run()
-        .wrap_err("Failed to set Darwin system profile")?;
+      Command::from_nix_command(
+        NixCommand::new(CommandKind::Build).print_build_logs(false),
+      )
+      .args(["--no-link", "--profile", SYSTEM_PROFILE])
+      .arg(&out_path)
+      .elevate(Some(elevation.clone()))
+      .dry(self.common.dry)
+      .with_required_env()
+      .run()
+      .wrap_err("Failed to set Darwin system profile")?;
 
       let darwin_rebuild = out_path.join("sw/bin/darwin-rebuild");
       let activate_user = out_path.join("activate-user");
@@ -233,8 +235,7 @@ impl DarwinReplArgs {
       attribute.push(hostname);
     }
 
-    Command::new("nix")
-      .arg("repl")
+    Command::nix(CommandKind::Repl)
       .args(target_installable.to_args())
       .with_required_env()
       .show_output(true)

--- a/crates/nh-home/src/home.rs
+++ b/crates/nh-home/src/home.rs
@@ -8,7 +8,7 @@ use color_eyre::{
   eyre::{Context, bail, eyre},
 };
 use nh_core::{
-  command::{self, Command},
+  command::{self, Command, CommandKind},
   update::update,
   util::{get_hostname, print_dix_diff},
 };
@@ -301,9 +301,8 @@ where
       if let Some(config_name) = configuration_name {
         // Verify the provided configuration exists
         let func = format!(r#" x: x ? "{config_name}" "#);
-        let check_res = Command::new("nix")
+        let check_res = Command::nix(CommandKind::Eval)
           .with_required_env()
-          .arg("eval")
           .args(&extra_args)
           .arg("--apply")
           .arg(func)
@@ -357,9 +356,8 @@ where
 
         for attr_name in [format!("{username}@{hostname}"), username] {
           let func = format!(r#" x: x ? "{attr_name}" "#);
-          let check_res = Command::new("nix")
+          let check_res = Command::nix(CommandKind::Eval)
             .with_required_env()
-            .arg("eval")
             .args(&extra_args)
             .arg("--apply")
             .arg(func)
@@ -450,9 +448,8 @@ impl HomeReplArgs {
       self.configuration.clone(),
     )?;
 
-    Command::new("nix")
+    Command::nix(CommandKind::Repl)
       .with_required_env()
-      .arg("repl")
       .args(toplevel.to_args())
       .show_output(true)
       .run()?;

--- a/crates/nh-nixos/src/generations.rs
+++ b/crates/nh-nixos/src/generations.rs
@@ -8,6 +8,7 @@ use std::{
 use chrono::{DateTime, Local, TimeZone, Utc};
 use clap::ValueEnum;
 use color_eyre::eyre::Result;
+use nh_core::command::{CommandKind, NixCommand};
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone)]
@@ -148,9 +149,11 @@ pub fn get_closure_sizes_batch(
     .map(|p| p.read_link().unwrap_or_else(|_| p.to_path_buf()))
     .collect();
 
-  let output = match process::Command::new("nix")
-    .args(["path-info", "-Sh", "--json"])
+  let output = match NixCommand::new(CommandKind::PathInfo)
+    .args(["-Sh", "--json"])
     .args(generation_dirs)
+    .with_required_env()
+    .to_std_command()
     .output()
   {
     Ok(out) => out,
@@ -193,9 +196,11 @@ pub fn get_closure_size(generation_dir: &Path) -> String {
     .unwrap_or_else(|_| generation_dir.to_path_buf());
   let store_path_str = store_path.to_string_lossy();
 
-  let output = match process::Command::new("nix")
-    .args(["path-info", "-Sh", "--json"])
+  let output = match NixCommand::new(CommandKind::PathInfo)
+    .args(["-Sh", "--json"])
     .arg(generation_dir)
+    .with_required_env()
+    .to_std_command()
     .output()
   {
     Ok(out) => out,

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -7,7 +7,7 @@ use std::{
 use color_eyre::eyre::{Context, Result, bail, eyre};
 use nh_core::{
   args::DiffType,
-  command::{self, Command, ElevationStrategy},
+  command::{self, Command, CommandKind, ElevationStrategy, NixCommand},
   update::update,
   util::{
     ensure_ssh_key_login,
@@ -416,13 +416,15 @@ impl OsRebuildActivateArgs {
           .canonicalize()
           .context("Failed to resolve base output path to store path")?;
 
-        Command::new("nix")
-          .elevate(elevate.then_some(elevation.clone()))
-          .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
-          .arg(&base_store_path)
-          .with_required_env()
-          .run()
-          .wrap_err("Failed to set system profile")?;
+        Command::from_nix_command(
+          NixCommand::new(CommandKind::Build).print_build_logs(false),
+        )
+        .elevate(elevate.then_some(elevation.clone()))
+        .args(["--no-link", "--profile", SYSTEM_PROFILE])
+        .arg(&base_store_path)
+        .with_required_env()
+        .run()
+        .wrap_err("Failed to set system profile")?;
 
         let mut cmd = Command::new(switch_to_configuration)
           .arg("boot")
@@ -1359,8 +1361,7 @@ impl OsReplArgs {
       attribute.push(hostname);
     }
 
-    Command::new("nix")
-      .arg("repl")
+    Command::nix(CommandKind::Repl)
       .args(target_installable.to_args())
       .with_required_env()
       .show_output(true)

--- a/crates/nh-remote/src/copy.rs
+++ b/crates/nh-remote/src/copy.rs
@@ -10,7 +10,7 @@ use color_eyre::{
   eyre::{Context, eyre},
 };
 use indicatif::{ProgressBar, ProgressStyle};
-use nh_core::command::exec_with_streaming;
+use nh_core::command::{CommandKind, NixCommand, exec_with_streaming};
 use subprocess::{Exec, Redirection};
 use tracing::{debug, error, info};
 
@@ -34,14 +34,13 @@ impl CopyDirection<'_> {
   fn args(self) -> Vec<String> {
     match self {
       Self::FromRemote(host) => {
-        vec!["copy".to_string(), "--from".to_string(), store_uri(host)]
+        vec!["--from".to_string(), store_uri(host)]
       },
       Self::ToRemote {
         host,
         use_substitutes,
       } => {
-        let mut args =
-          vec!["copy".to_string(), "--to".to_string(), store_uri(host)];
+        let mut args = vec!["--to".to_string(), store_uri(host)];
         push_substitute_on_destination(&mut args, use_substitutes);
         args
       },
@@ -51,7 +50,6 @@ impl CopyDirection<'_> {
         use_substitutes,
       } => {
         let mut args = vec![
-          "copy".to_string(),
           "--from".to_string(),
           store_uri(from_host),
           "--to".to_string(),
@@ -82,13 +80,16 @@ fn build_nix_copy_command<P: Into<OsString>>(
   path: P,
 ) -> Exec {
   let flake_flags = get_flake_flags();
-  let mut cmd = Exec::cmd("nix").args(&flake_flags);
+  let mut cmd = NixCommand::new(CommandKind::Copy).global_args(&flake_flags);
 
   for arg in direction.args() {
     cmd = cmd.arg(arg);
   }
 
-  cmd.arg(path).env("NIX_SSHOPTS", get_nix_sshopts_env())
+  cmd
+    .arg(path.into())
+    .env("NIX_SSHOPTS", get_nix_sshopts_env())
+    .to_exec()
 }
 
 /// Copy a Nix closure from a remote host to localhost.
@@ -324,7 +325,6 @@ mod tests {
       }
       .args(),
       vec![
-        "copy",
         "--to",
         "ssh-ng://build.example",
         "--substitute-on-destination",
@@ -342,12 +342,7 @@ mod tests {
         use_substitutes: true,
       }
       .args(),
-      vec![
-        "copy",
-        "--to",
-        "ssh://build.example",
-        "--substitute-on-destination",
-      ]
+      vec!["--to", "ssh://build.example", "--substitute-on-destination",]
     );
   }
 
@@ -356,7 +351,6 @@ mod tests {
     let host = RemoteHost::parse("build.example").unwrap();
 
     assert_eq!(CopyDirection::FromRemote(&host).args(), vec![
-      "copy",
       "--from",
       "ssh-ng://build.example"
     ]);
@@ -375,7 +369,6 @@ mod tests {
       }
       .args(),
       vec![
-        "copy",
         "--from",
         "ssh-ng://build.example",
         "--to",
@@ -395,7 +388,7 @@ mod tests {
         use_substitutes: false,
       }
       .args(),
-      vec!["copy", "--to", "ssh-ng://user@[2001:db8::1]"]
+      vec!["--to", "ssh-ng://user@[2001:db8::1]"]
     );
   }
 

--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -17,7 +17,13 @@ use color_eyre::{
   eyre::{Context, bail, eyre},
 };
 use nh_core::{
-  command::{ElevationStrategy, cache_password, get_cached_password},
+  command::{
+    CommandKind,
+    ElevationStrategy,
+    NixCommand,
+    cache_password,
+    get_cached_password,
+  },
   util::NixVariant,
 };
 use nh_installable::Installable;
@@ -1343,11 +1349,12 @@ fn eval_drv_path(installable: &Installable) -> Result<PathBuf> {
   debug!("Evaluating drvPath: nix eval --raw {:?}", args);
 
   let flake_flags = get_flake_flags();
-  let cmd = Exec::cmd("nix")
-    .args(&flake_flags)
-    .arg("eval")
+  let cmd = NixCommand::new(CommandKind::Eval)
+    .global_args(&flake_flags)
     .arg("--raw")
     .args(&args)
+    .with_required_env()
+    .to_exec()
     .stdout(Redirection::Pipe)
     .stderr(Redirection::Pipe);
 
@@ -1562,14 +1569,18 @@ fn build_nix_command(
   let flake_flags = get_flake_flags();
   let extra_args_strings = convert_extra_args(extra_args)?;
 
-  let mut args = vec!["nix".to_string()];
-  args.extend(flake_flags.iter().map(|s| (*s).to_string()));
-  args.push("build".to_string());
-  args.push(drv_with_outputs.to_string());
-  args.extend(extra_flags.iter().map(|s| (*s).to_string()));
-  args.extend(extra_args_strings);
-
-  Ok(args)
+  Ok(
+    NixCommand::new(CommandKind::Build)
+      .print_build_logs(false)
+      .global_args(&flake_flags)
+      .arg(drv_with_outputs)
+      .args(extra_flags)
+      .args(extra_args_strings)
+      .argv()
+      .into_iter()
+      .map(|arg| arg.to_string_lossy().into_owned())
+      .collect(),
+  )
 }
 
 /// Build on remote without nom - just capture output.

--- a/crates/nh-search/Cargo.toml
+++ b/crates/nh-search/Cargo.toml
@@ -13,6 +13,7 @@ color-eyre.workspace          = true
 elasticsearch-dsl.workspace   = true
 indicatif.workspace           = true
 inquire.workspace             = true
+nix-command.workspace         = true
 regex.workspace               = true
 reqwest.workspace             = true
 secrecy.workspace             = true

--- a/crates/nh-search/src/render/common.rs
+++ b/crates/nh-search/src/render/common.rs
@@ -1,7 +1,8 @@
 use std::sync::OnceLock;
 
+use nix_command::{CommandKind, NixCommand};
 use regex::Regex;
-use subprocess::{Exec, Redirection};
+use subprocess::Redirection;
 use tracing::warn;
 
 static HYPERLINKS_SUPPORTED: OnceLock<bool> = OnceLock::new();
@@ -74,14 +75,16 @@ pub(super) fn resolve_nixpkgs_path(channel: &str) -> String {
   };
 
   let flake_path = format!("{flake_ref}#path");
-  capture_nix_path(&["eval", "--raw", &flake_path])
-    .or_else(|| capture_nix_path(&["eval", "-f", "<nixpkgs>", "path"]))
+  capture_nix_path(&["--raw", &flake_path])
+    .or_else(|| capture_nix_path(&["-f", "<nixpkgs>", "path"]))
     .unwrap_or_default()
 }
 
 fn capture_nix_path(args: &[&str]) -> Option<String> {
-  let capture = Exec::cmd("nix")
+  let capture = NixCommand::new(CommandKind::Eval)
     .args(args)
+    .with_required_env()
+    .to_exec()
     .stderr(Redirection::None)
     .stdout(Redirection::Pipe)
     .capture()


### PR DESCRIPTION
This as been sitting on my laptop for a while. 

Change-Id: I9451f2b7912ecac23c3cc08e982669576a6a6964
