### PR TITLE
flake: hardcode supported systems for performance reasons

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,7 @@
 
       pkgsFor = system: nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
 
-      supportedSystems = builtins.filter (
-        system: (builtins.tryEval (pkgsFor system).stdenv.hostPlatform).success
-      ) (lib.systems.doubles.linux ++ lib.systems.doubles.darwin);
+      supportedSystems = lib.systems.doubles.linux ++ lib.systems.doubles.darwin;
 
       forAllSystems = function: lib.genAttrs supportedSystems (system: function (pkgsFor system));
 


### PR DESCRIPTION
With the previous version, a version of nixpkgs was instantiated for every single system. This is _horrible_ for performance.

Checking in the repl, all the systems function. If you'd like to still do some form of filtering, fine. Just _please_ don't create a `pkgs` instance for all of them.

## Sanity Checking

I solemnly swear this is sane, and all all relevant checkboxes would be checked. 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
