### PR TITLE
various: add `NH_SSHOPTS`; support `NIX_SUDOOPTS` and `NH_SUDOOPTS`; `NIXOS_NO_CHECK` compat

### DIFF
--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -1,6 +1,7 @@
 use std::{
   collections::HashMap,
   convert::Infallible,
+  env,
   ffi::{OsStr, OsString},
   io::{Read, Write},
   path::PathBuf,
@@ -21,6 +22,26 @@ use tracing::{debug, info, warn};
 use which::which;
 
 use crate::args::NixBuildPassthroughArgs;
+
+#[must_use]
+pub fn get_sudo_opts() -> Vec<String> {
+  let sudoopts = env::var("NH_SUDOOPTS")
+    .or_else(|_| env::var("NIX_SUDOOPTS"))
+    .ok()
+    .filter(|s| !s.is_empty());
+
+  let Some(opts) = sudoopts else {
+    return Vec::new();
+  };
+
+  shlex::split(&opts).unwrap_or_else(|| {
+    warn!(
+      "Failed to parse sudo opts from NH_SUDOOPTS/NIX_SUDOOPTS, ignoring. \
+       Value: {opts}"
+    );
+    Vec::new()
+  })
+}
 
 /// Execute a command, streaming output to stdout/stderr while optionally
 /// capturing it for error reporting.
@@ -507,7 +528,7 @@ impl Command {
     ];
 
     // Always explicitly set USER if present
-    if let Ok(user) = std::env::var("USER") {
+    if let Ok(user) = env::var("USER") {
       self
         .env_vars
         .insert("USER".to_string(), EnvAction::Set(user));
@@ -515,7 +536,7 @@ impl Command {
 
     // Only propagate HOME for non-elevated commands
     if self.elevate.is_none()
-      && let Ok(home) = std::env::var("HOME")
+      && let Ok(home) = env::var("HOME")
     {
       self
         .env_vars
@@ -532,13 +553,13 @@ impl Command {
 
     // Preserve all variables in PRESERVE_ENV if present
     for &key in PRESERVE_ENV {
-      if std::env::var(key).is_ok() {
+      if env::var(key).is_ok() {
         self.env_vars.insert(key.to_string(), EnvAction::Preserve);
       }
     }
 
     // Explicitly set NH_* variables
-    for (key, value) in std::env::vars() {
+    for (key, value) in env::vars() {
       if key.starts_with("NH_") {
         self.env_vars.insert(key, EnvAction::Set(value));
       }
@@ -571,7 +592,7 @@ impl Command {
         },
         EnvAction::Preserve => {
           // Only preserve if present in current environment
-          if let Ok(value) = std::env::var(key) {
+          if let Ok(value) = env::var(key) {
             cmd = cmd.env(key, value);
           }
         },
@@ -611,7 +632,7 @@ impl Command {
       })?;
     if program_name == "sudo"
       && !matches!(elevation_strategy, ElevationStrategy::Passwordless)
-      && let Ok(askpass) = std::env::var("NH_SUDO_ASKPASS")
+      && let Ok(askpass) = env::var("NH_SUDO_ASKPASS")
     {
       cmd = cmd.env("SUDO_ASKPASS", askpass).arg("-A");
     }
@@ -623,9 +644,13 @@ impl Command {
       cmd = cmd.arg("--pty-late");
     }
 
+    if program_name == "sudo" {
+      cmd = cmd.args(get_sudo_opts());
+    }
+
     // NH_PRESERVE_ENV: set to "0" to disable preserving environment variables,
     // "1" to force, unset defaults to force
-    let preserve_env = std::env::var("NH_PRESERVE_ENV")
+    let preserve_env = env::var("NH_PRESERVE_ENV")
       .as_deref()
       .map_or(true, |x| !matches!(x, "0"));
 
@@ -636,9 +661,7 @@ impl Command {
       match action {
         EnvAction::Set(value) => Some(format!("{key}={value}")),
         EnvAction::Preserve if preserve_env => {
-          std::env::var(key)
-            .ok()
-            .map(|value| format!("{key}={value}"))
+          env::var(key).ok().map(|value| format!("{key}={value}"))
         },
         _ => None,
       }
@@ -666,7 +689,7 @@ impl Command {
         eyre::eyre!("Failed to determine elevation program name")
       })?;
     if program_name == "sudo"
-      && let Ok(_askpass) = std::env::var("NH_SUDO_ASKPASS")
+      && let Ok(_askpass) = env::var("NH_SUDO_ASKPASS")
     {
       parts.push("-A".to_string());
     }
@@ -678,7 +701,11 @@ impl Command {
       parts.push("--pty-late".to_string());
     }
 
-    let preserve_env = std::env::var("NH_PRESERVE_ENV")
+    if program_name == "sudo" {
+      parts.extend(get_sudo_opts());
+    }
+
+    let preserve_env = env::var("NH_PRESERVE_ENV")
       .as_deref()
       .map_or(true, |x| !matches!(x, "0"));
 
@@ -687,8 +714,7 @@ impl Command {
       match action {
         EnvAction::Set(value) => Some(format!("{key}={value}")),
         EnvAction::Preserve if preserve_env => {
-          std::env::var(key)
-            .map_or(None, |value| Some(format!("{key}={value}")))
+          env::var(key).map_or(None, |value| Some(format!("{key}={value}")))
         },
         _ => None,
       }
@@ -709,8 +735,8 @@ impl Command {
     strategy: ElevationStrategy,
   ) -> Result<std::process::Command> {
     // Get the current executable path
-    let current_exe = std::env::current_exe()
-      .context("Failed to get current executable path")?;
+    let current_exe =
+      env::current_exe().context("Failed to get current executable path")?;
 
     // Self-elevation with proper environment handling
     let cmd_builder = Self::new(&current_exe)
@@ -721,7 +747,7 @@ impl Command {
 
     // Add the target executable and arguments
     sudo_parts.push(current_exe.to_string_lossy().to_string());
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = env::args().skip(1).collect();
     sudo_parts.extend(args);
 
     let mut std_cmd = std::process::Command::new(&sudo_parts[0]);
@@ -731,7 +757,7 @@ impl Command {
 
     // check if using SUDO_ASKPASS
     if sudo_parts[1] == "-A"
-      && let Ok(askpass) = std::env::var("NH_SUDO_ASKPASS")
+      && let Ok(askpass) = env::var("NH_SUDO_ASKPASS")
     {
       std_cmd.env("SUDO_ASKPASS", askpass);
     }
@@ -801,6 +827,7 @@ impl Command {
       // Add program-specific arguments
       if program_name == "sudo" {
         elev_cmd = elev_cmd.arg("--prompt=").arg("--stdin");
+        elev_cmd = elev_cmd.args(get_sudo_opts());
       }
 
       // Add env command to handle environment variables
@@ -813,7 +840,7 @@ impl Command {
             elev_cmd = elev_cmd.arg(format!("{key}={quoted_value}"));
           },
           EnvAction::Preserve => {
-            if let Ok(value) = std::env::var(key) {
+            if let Ok(value) = env::var(key) {
               let quoted_value = shlex::try_quote(&value)
                 .unwrap_or_else(|_| value.clone().into());
               elev_cmd = elev_cmd.arg(format!("{key}={quoted_value}"));

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -381,7 +381,7 @@ impl OsRebuildActivateArgs {
           .arg("test")
           .message("Activating configuration")
           .elevate(elevate.then_some(elevation.clone()))
-          .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"])
+          .preserve_envs(["NIXOS_INSTALL_BOOTLOADER", "NIXOS_NO_CHECK"])
           .with_required_env()
           .show_output(self.show_activation_logs)
           .run()
@@ -434,7 +434,7 @@ impl OsRebuildActivateArgs {
           .arg("boot")
           .elevate(elevate.then_some(elevation))
           .message("Adding configuration to bootloader")
-          .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"]);
+          .preserve_envs(["NIXOS_INSTALL_BOOTLOADER", "NIXOS_NO_CHECK"]);
 
         if self.rebuild.install_bootloader {
           cmd = cmd.set_env("NIXOS_INSTALL_BOOTLOADER", "1");
@@ -846,7 +846,7 @@ impl OsRollbackArgs {
     match Command::new(&switch_to_configuration)
       .arg("switch")
       .elevate(elevate.then_some(elevation.clone()))
-      .preserve_envs(["NIXOS_INSTALL_BOOTLOADER"])
+      .preserve_envs(["NIXOS_INSTALL_BOOTLOADER", "NIXOS_NO_CHECK"])
       .with_required_env()
       .run()
     {

--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -23,6 +23,7 @@ use nh_core::{
     NixCommand,
     cache_password,
     get_cached_password,
+    get_sudo_opts,
   },
   util::NixVariant,
 };
@@ -88,9 +89,9 @@ fn build_remote_command(
     match (program_name, strategy) {
       // sudo passwordless: use --non-interactive to fail if password required
       ("sudo", ElevationStrategy::Passwordless) => {
-        Ok(format!("sudo --non-interactive {base_cmd}"))
+        Ok(remote_sudo_command("--non-interactive", base_cmd))
       },
-      ("sudo", _) => Ok(format!("sudo --prompt= --stdin {base_cmd}")),
+      ("sudo", _) => Ok(remote_sudo_command("--prompt= --stdin", base_cmd)),
       // doas passwordless: use -n flag (non-interactive)
       ("doas", ElevationStrategy::Passwordless) => {
         Ok(format!("doas -n {base_cmd}"))
@@ -144,6 +145,39 @@ fn build_remote_command(
   } else {
     Ok(base_cmd.to_string())
   }
+}
+
+fn remote_sudo_command(prefix: &str, base_cmd: &str) -> String {
+  let sudo_opts = get_sudo_opts()
+    .iter()
+    .map(|opt| shell_quote(opt))
+    .collect::<Vec<_>>()
+    .join(" ");
+
+  if sudo_opts.is_empty() {
+    format!("sudo {prefix} {base_cmd}")
+  } else {
+    format!("sudo {prefix} {sudo_opts} {base_cmd}")
+  }
+}
+
+fn nixos_activation_command(
+  switch_to_config: &str,
+  action: &str,
+  install_bootloader: bool,
+) -> String {
+  let mut parts = Vec::new();
+
+  if install_bootloader {
+    parts.push("NIXOS_INSTALL_BOOTLOADER=1".to_string());
+  }
+
+  if let Ok(no_check) = env::var("NIXOS_NO_CHECK") {
+    parts.push(format!("NIXOS_NO_CHECK={}", shell_quote(&no_check)));
+  }
+
+  parts.push(format!("{} {action}", shell_quote(switch_to_config)));
+  parts.join(" ")
 }
 
 /// Register a SIGINT handler that sets the global interrupt flag.
@@ -646,26 +680,35 @@ fn shell_quote(s: &str) -> String {
   )
 }
 
-/// Get SSH options from `NIX_SSHOPTS` plus our defaults. This includes
-/// connection multiplexing options (`ControlMaster`, `ControlPath`,
-/// `ControlPersist`) which enable efficient reuse of SSH connections.
+/// Get SSH options from `NH_SSHOPTS` (or `NIX_SSHOPTS` for compatibility)
+/// plus our defaults. This includes connection multiplexing options
+/// (`ControlMaster`, `ControlPath`, `ControlPersist`) which enable efficient
+/// reuse of SSH connections.
 pub fn get_ssh_opts() -> Vec<String> {
   let mut opts: Vec<String> = Vec::new();
 
-  // User options first (from NIX_SSHOPTS)
-  if let Ok(sshopts) = env::var("NIX_SSHOPTS") {
-    if let Some(parsed) = shlex::split(&sshopts) {
+  // NH_SSHOPTS takes precedence; NIX_SSHOPTS is the compatibility fallback.
+  let (sshopts_var, sshopts_val) = env::var("NH_SSHOPTS").map_or_else(
+    |_| {
+      env::var("NIX_SSHOPTS")
+        .map_or_else(|_| ("", String::new()), |v| ("NIX_SSHOPTS", v))
+    },
+    |v| ("NH_SSHOPTS", v),
+  );
+
+  if !sshopts_val.is_empty() {
+    if let Some(parsed) = shlex::split(&sshopts_val) {
       opts.extend(parsed);
     } else {
-      let truncated = sshopts.chars().take(60).collect::<String>();
-      let sshopts_display = if sshopts.len() > 60 {
+      let truncated = sshopts_val.chars().take(60).collect::<String>();
+      let sshopts_display = if sshopts_val.len() > 60 {
         format!("{truncated}...")
       } else {
         truncated
       };
       warn!(
-        "Failed to parse NIX_SSHOPTS, ignoring. Provide valid options or use \
-         ~/.ssh/config. Value: {sshopts_display}",
+        "Failed to parse {sshopts_var}, ignoring. Provide valid options or \
+         use ~/.ssh/config. Value: {sshopts_display}",
       );
     }
   }
@@ -676,15 +719,19 @@ pub fn get_ssh_opts() -> Vec<String> {
   opts
 }
 
-/// Get `NIX_SSHOPTS` environment value with our defaults appended.
-/// Used for Nix SSH store commands which read `NIX_SSHOPTS`.
+/// Get SSH options as a string suitable for the `NIX_SSHOPTS` environment
+/// variable passed to Nix store commands. Reads `NH_SSHOPTS` (preferred) or
+/// `NIX_SSHOPTS` (compatibility) and appends our defaults.
 ///
 /// Note: Nix SSH store commands do not provide a structured argv channel for
 /// these options, so values containing spaces cannot be reliably passed through
 /// this mechanism. Users needing complex SSH options should use
 /// `~/.ssh/config` instead.
 fn get_nix_sshopts_env() -> String {
-  let user_opts = env::var("NIX_SSHOPTS").unwrap_or_default();
+  // NH_SSHOPTS takes precedence; NIX_SSHOPTS is the compatibility fallback.
+  let user_opts = env::var("NH_SSHOPTS")
+    .or_else(|_| env::var("NIX_SSHOPTS"))
+    .unwrap_or_default();
   let default_opts = get_default_ssh_opts();
 
   if user_opts.is_empty() {
@@ -1189,7 +1236,7 @@ fn activate_nixos_remote(
       ssh_cmd = ssh_cmd.arg(host.ssh_host());
 
       // Build the remote command using helper function
-      let base_cmd = format!("{} {}", shell_quote(switch_path_str), action);
+      let base_cmd = nixos_activation_command(switch_path_str, action, false);
       let remote_cmd =
         build_remote_command(config.elevation.as_ref(), &base_cmd)?;
 
@@ -1270,16 +1317,13 @@ fn activate_nixos_remote(
       boot_ssh_cmd = boot_ssh_cmd.arg(host.ssh_host());
 
       // Build the remote command using helper function
-      let boot_remote_cmd = if config.install_bootloader {
-        let base_cmd = format!(
-          "NIXOS_INSTALL_BOOTLOADER=1 {} boot",
-          shell_quote(switch_path_str)
-        );
-        build_remote_command(config.elevation.as_ref(), &base_cmd)?
-      } else {
-        let base_cmd = format!("{} boot", shell_quote(switch_path_str));
-        build_remote_command(config.elevation.as_ref(), &base_cmd)?
-      };
+      let base_cmd = nixos_activation_command(
+        switch_path_str,
+        "boot",
+        config.install_bootloader,
+      );
+      let boot_remote_cmd =
+        build_remote_command(config.elevation.as_ref(), &base_cmd)?;
 
       boot_ssh_cmd = boot_ssh_cmd.arg(boot_remote_cmd);
 
@@ -1823,6 +1867,42 @@ mod tests {
   use proptest::prelude::*;
   use serial_test::serial;
 
+  struct SshOptsEnvGuard {
+    nh_sshopts:  Option<OsString>,
+    nix_sshopts: Option<OsString>,
+  }
+
+  impl SshOptsEnvGuard {
+    fn new() -> Self {
+      Self {
+        nh_sshopts:  env::var_os("NH_SSHOPTS"),
+        nix_sshopts: env::var_os("NIX_SSHOPTS"),
+      }
+    }
+
+    fn clear(&self) {
+      unsafe {
+        env::remove_var("NH_SSHOPTS");
+        env::remove_var("NIX_SSHOPTS");
+      }
+    }
+  }
+
+  impl Drop for SshOptsEnvGuard {
+    fn drop(&mut self) {
+      unsafe {
+        match &self.nh_sshopts {
+          Some(value) => env::set_var("NH_SSHOPTS", value),
+          None => env::remove_var("NH_SSHOPTS"),
+        }
+        match &self.nix_sshopts {
+          Some(value) => env::set_var("NIX_SSHOPTS", value),
+          None => env::remove_var("NIX_SSHOPTS"),
+        }
+      }
+    }
+  }
+
   use super::*;
 
   proptest! {
@@ -2160,10 +2240,9 @@ mod tests {
   #[test]
   #[serial]
   fn test_get_ssh_opts_default() {
-    // Clear env var for test
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     let opts = get_ssh_opts();
     assert!(opts.contains(&"-o".to_string()));
     assert!(opts.contains(&"ControlMaster=auto".to_string()));
@@ -2175,8 +2254,11 @@ mod tests {
   #[test]
   #[serial]
   fn test_get_ssh_opts_with_simple_nix_sshopts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     unsafe {
-      std::env::set_var("NIX_SSHOPTS", "-p 2222 -i /path/to/key");
+      env::set_var("NIX_SSHOPTS", "-p 2222 -i /path/to/key");
     }
     let opts = get_ssh_opts();
     // User options should be included
@@ -2186,17 +2268,17 @@ mod tests {
     assert!(opts.contains(&"/path/to/key".to_string()));
     // Default options should still be present
     assert!(opts.contains(&"ControlMaster=auto".to_string()));
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
   }
 
   #[test]
   #[serial]
   fn test_get_ssh_opts_with_quoted_nix_sshopts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     // Test that quoted paths with spaces are handled correctly
     unsafe {
-      std::env::set_var("NIX_SSHOPTS", r#"-i "/path/with spaces/key""#);
+      env::set_var("NIX_SSHOPTS", r#"-i "/path/with spaces/key""#);
     }
     let opts = get_ssh_opts();
     // The path should be parsed as a single argument without quotes
@@ -2204,27 +2286,53 @@ mod tests {
     assert!(opts.contains(&"/path/with spaces/key".to_string()));
     // Default options should still be present
     assert!(opts.contains(&"ControlMaster=auto".to_string()));
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
   }
 
   #[test]
   #[serial]
   fn test_get_ssh_opts_with_option_value_nix_sshopts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     // Test -o with quoted value containing spaces
     unsafe {
-      std::env::set_var(
-        "NIX_SSHOPTS",
-        r#"-o "ProxyCommand=ssh -W %h:%p jump""#,
-      );
+      env::set_var("NIX_SSHOPTS", r#"-o "ProxyCommand=ssh -W %h:%p jump""#);
     }
     let opts = get_ssh_opts();
     assert!(opts.contains(&"-o".to_string()));
     assert!(opts.contains(&"ProxyCommand=ssh -W %h:%p jump".to_string()));
+  }
+
+  #[test]
+  #[serial]
+  fn test_get_ssh_opts_with_nh_sshopts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
+      env::set_var("NH_SSHOPTS", "-p 2222 -i /path/to/key");
     }
+    let opts = get_ssh_opts();
+    assert!(opts.contains(&"-p".to_string()));
+    assert!(opts.contains(&"2222".to_string()));
+    assert!(opts.contains(&"-i".to_string()));
+    assert!(opts.contains(&"/path/to/key".to_string()));
+    assert!(opts.contains(&"ControlMaster=auto".to_string()));
+  }
+
+  #[test]
+  #[serial]
+  fn test_get_ssh_opts_nh_sshopts_takes_precedence() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
+    unsafe {
+      env::set_var("NH_SSHOPTS", "-p 2222");
+      env::set_var("NIX_SSHOPTS", "-p 9999");
+    }
+    let opts = get_ssh_opts();
+    assert!(opts.contains(&"2222".to_string()));
+    assert!(!opts.contains(&"9999".to_string()));
   }
 
   #[test]
@@ -2301,9 +2409,9 @@ mod tests {
   #[test]
   #[serial]
   fn test_get_nix_sshopts_env_empty() {
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     let result = get_nix_sshopts_env();
     // Should contain our defaults as space-separated values
     assert!(result.contains("-o"));
@@ -2316,49 +2424,78 @@ mod tests {
   #[test]
   #[serial]
   fn test_get_nix_sshopts_env_simple() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     unsafe {
-      std::env::set_var("NIX_SSHOPTS", "-p 2222");
+      env::set_var("NIX_SSHOPTS", "-p 2222");
     }
     let result = get_nix_sshopts_env();
     // User options should come first
     assert!(result.starts_with("-p 2222"));
     // Defaults should be appended
     assert!(result.contains("ControlMaster=auto"));
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
   }
 
   #[test]
   #[serial]
   fn test_get_nix_sshopts_env_preserves_user_opts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     // User options are preserved as-is.
     unsafe {
-      std::env::set_var("NIX_SSHOPTS", "-i /path/to/key -p 22");
+      env::set_var("NIX_SSHOPTS", "-i /path/to/key -p 22");
     }
     let result = get_nix_sshopts_env();
     // User options preserved at start
     assert!(result.starts_with("-i /path/to/key -p 22"));
     // Our defaults appended
     assert!(result.contains("ControlMaster=auto"));
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
   }
 
   #[test]
   #[serial]
   fn test_get_nix_sshopts_env_no_extra_quoting() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
     // Verify we don't add shell quotes around NIX_SSHOPTS.
-    unsafe {
-      std::env::remove_var("NIX_SSHOPTS");
-    }
     let result = get_nix_sshopts_env();
     // Should NOT contain shell quote characters around our options
     assert!(!result.contains("'ControlMaster"));
     assert!(!result.contains("\"ControlMaster"));
     // Values should be bare
     assert!(result.contains("-o ControlMaster=auto"));
+  }
+
+  #[test]
+  #[serial]
+  fn test_get_nix_sshopts_env_nh_sshopts() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
+    unsafe {
+      env::set_var("NH_SSHOPTS", "-p 2222");
+    }
+    let result = get_nix_sshopts_env();
+    assert!(result.starts_with("-p 2222"));
+    assert!(result.contains("ControlMaster=auto"));
+  }
+
+  #[test]
+  #[serial]
+  fn test_get_nix_sshopts_env_nh_sshopts_takes_precedence() {
+    let env_guard = SshOptsEnvGuard::new();
+    env_guard.clear();
+
+    unsafe {
+      env::set_var("NH_SSHOPTS", "-p 2222");
+      env::set_var("NIX_SSHOPTS", "-p 9999");
+    }
+    let result = get_nix_sshopts_env();
+    assert!(result.contains("2222"));
+    assert!(!result.contains("9999"));
   }
 
   #[test]

--- a/crates/xtask/src/man.rs
+++ b/crates/xtask/src/man.rs
@@ -116,13 +116,34 @@ pub fn generate(out_dir: &str) -> Result<(), String> {
        due to fragile behavior.",
     ),
     (
+      "NH_SSHOPTS",
+      "SSH options for remote operations. Takes precedence over NIX_SSHOPTS. \
+       Accepts the same format as NIX_SSHOPTS.",
+    ),
+    (
+      "NH_SUDOOPTS",
+      "Extra arguments inserted into the sudo invocation when NH elevates \
+       privileges. Takes precedence over NIX_SUDOOPTS.",
+    ),
+    (
       "NIXOS_INSTALL_BOOTLOADER",
       "Forwarded to switch-to-configuration. If true, forces bootloader \
        installation. Also available via --install-bootloader.",
     ),
     (
+      "NIXOS_NO_CHECK",
+      "Forwarded to switch-to-configuration during activation. Inhibits \
+       certain NixOS service checks.",
+    ),
+    (
       "NIX_SSHOPTS",
-      "SSH options passed to Nix commands for remote builds.",
+      "SSH options passed to Nix commands for remote builds. NH_SSHOPTS takes \
+       precedence when both are set.",
+    ),
+    (
+      "NIX_SUDOOPTS",
+      "Extra arguments inserted into the sudo invocation. Supported for \
+       nixos-rebuild compatibility; NH_SUDOOPTS takes precedence.",
     ),
     (
       "NIX_CONFIG",

--- a/docs/README.md
+++ b/docs/README.md
@@ -363,13 +363,18 @@ the common variables that you may encounter or choose to employ are as follows:
 
 - `NIX_SSHOPTS`, `NIX_CONFIG`, `NIX_REMOTE`, `NIX_SSL_CERT_FILE` and
   `NIX_USER_CONF_FILES` are forwarded in all Nix commands with environment
-  isolation.
+  isolation. `NH_SSHOPTS` takes precedence over `NIX_SSHOPTS` when both are set.
+- `NIX_SUDOOPTS` - Extra sudo arguments forwarded to the `sudo` invocation;
+  supported for nixos-rebuild compatibility. `NH_SUDOOPTS` takes precedence when
+  both are set.
 - `NIXOS_INSTALL_BOOTLOADER`
   - This is a variable accepted by `switch-to-configuration`, which handles the
     system switching behind the scenes. If `true`, `switch-to-configuration`
-    will call the necessary script to force and installation of your bootloader.
+    will call the necessary script to force installation of your bootloader.
     This behaviour can also be replicated by passing `--install-bootloader` to
     `nh os switch` and `nh os boot` commands.
+- `NIXOS_NO_CHECK` - Forwarded to `switch-to-configuration` during activation.
+  Inhibits certain NixOS service checks.
 
 ### NH Specific
 
@@ -394,6 +399,15 @@ the common variables that you may encounter or choose to employ are as follows:
   - Path to a program used as `SUDO_ASKPASS` when NH self-elevates with `sudo`.
     If set and `sudo` is used for elevation, NH will pass `-A` to `sudo` and set
     `SUDO_ASKPASS` accordingly.
+
+- `NH_SUDOOPTS`
+  - Extra arguments inserted into the `sudo` invocation when NH elevates
+    privileges. Accepts the same shell-quoted format as `NIX_SUDOOPTS`, which it
+    takes precedence over.
+
+- `NH_SSHOPTS`
+  - SSH options for remote operations. Accepts the same format as `NIX_SSHOPTS`,
+    which it takes precedence over.
 
 - `NH_PRESERVE_ENV`
   - Controls whether environment variables marked for preservation are passed to

--- a/docs/remote-build.md
+++ b/docs/remote-build.md
@@ -82,8 +82,9 @@ Hosts can be specified in several formats:
 
 > [!NOTE]
 > Due to restrictions of Nix's SSH remote handling, ports cannot be specified in
-> the host string. Use `NIX_SSHOPTS="-p 2222"` or configure ports in
-> `~/.ssh/config` for the host you are building on/deploying to.
+> the host string. Use `NH_SSHOPTS="-p 2222"` (`NIX_SSHOPTS` is also supported
+> for nixos-rebuild compatibility) or configure ports in `~/.ssh/config` for the
+> host you are building on/deploying to.
 
 ## SSH Configuration
 
@@ -118,14 +119,16 @@ ensuring no lingering SSH processes remain.
 
 ### Custom SSH Options
 
-Use the `NIX_SSHOPTS` environment variable to pass additional SSH options:
+Use `NH_SSHOPTS` to pass additional SSH options (or `NIX_SSHOPTS` for
+compatibility with nixos-rebuild):
 
 ```bash
-NIX_SSHOPTS="-p 2222 -i ~/.ssh/custom_key" nh os switch --build-host user@host
+NH_SSHOPTS="-p 2222 -i ~/.ssh/custom_key" nh os switch --build-host user@host
 ```
 
-Options in `NIX_SSHOPTS` are merged with the default options. For persistent
-configuration, use `~/.ssh/config`:
+`NH_SSHOPTS` takes precedence over `NIX_SSHOPTS` when both are set. Options are
+merged with the default options. For persistent configuration, use
+`~/.ssh/config`:
 
 ```plaintext
 Host buildserver


### PR DESCRIPTION
Introduces a few new env variables originally supported by nixos-rebuild alongside their new NH counterparts for better SSH and sudo execution. This is not strictly necessary, but it is valuable for consistency and providing people a path that they're *used to* for those migrating from legacy nixos-rebuild.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
