### PR TITLE
nh-core: support `--option` and `--override-input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ functionality, under the "Removed" section.
 
 ### Added
 
+- `--option NAME VALUE` passthrough flag (repeatable) for setting arbitrary Nix
+  configuration options per-invocation, e.g. `--option sandbox false`. Forwarded
+  to all underlying `nix` commands.
+- `--override-input INPUT FLAKE_URL` passthrough flag (repeatable) for
+  overriding specific flake inputs without editing `flake.lock`.
+- `NH_SSHOPTS` environment variable as the NH-native alias for `NIX_SSHOPTS`.
+  `NH_SSHOPTS` takes precedence when both are set.
+- `NH_SUDOOPTS` environment variable for passing extra arguments to the `sudo`
+  invocation when NH elevates privileges. `NIX_SUDOOPTS` is also accepted for
+  nixos-rebuild compatibility, with `NH_SUDOOPTS` taking precedence.
+- `NIXOS_NO_CHECK` is now forwarded to `switch-to-configuration` during
+  activation, matching nixos-rebuild behaviour.
 - `nh search offline <query>` subcommand for offline search using
   [spam-db](https://github.com/feel-co/spam) databases. Requires `-D <path>` (or
   `NH_OFFLINE_DB`) pointing to the database directory.

--- a/crates/nh-core/src/args.rs
+++ b/crates/nh-core/src/args.rs
@@ -146,6 +146,14 @@ pub struct NixBuildPassthroughArgs {
   /// Output results in JSON format
   #[arg(long)]
   pub json: bool,
+
+  /// Set a Nix configuration option (may be given multiple times)
+  #[arg(long, number_of_values = 2, value_names = ["NAME", "VALUE"])]
+  pub option: Vec<String>,
+
+  /// Override a specific flake input (may be given multiple times)
+  #[arg(long, number_of_values = 2, value_names = ["INPUT", "FLAKE_URL"])]
+  pub override_input: Vec<String>,
 }
 
 impl NixBuildPassthroughArgs {
@@ -228,6 +236,16 @@ impl NixBuildPassthroughArgs {
     if self.json {
       args.push("--json".into());
     }
+    for pair in self.option.chunks(2) {
+      args.push("--option".into());
+      args.push(pair[0].clone());
+      args.push(pair[1].clone());
+    }
+    for pair in self.override_input.chunks(2) {
+      args.push("--override-input".into());
+      args.push(pair[0].clone());
+      args.push(pair[1].clone());
+    }
 
     args
   }
@@ -245,5 +263,39 @@ mod tests {
     };
 
     assert_eq!(args.generate_passthrough_args(), ["--quiet"]);
+  }
+
+  #[test]
+  fn option_pairs_are_emitted() {
+    let args = NixBuildPassthroughArgs {
+      option: vec![
+        "sandbox".into(),
+        "false".into(),
+        "cores".into(),
+        "4".into(),
+      ],
+      ..Default::default()
+    };
+
+    assert_eq!(args.generate_passthrough_args(), [
+      "--option", "sandbox", "false", "--option", "cores", "4"
+    ]);
+  }
+
+  #[test]
+  fn override_input_pairs_are_emitted() {
+    let args = NixBuildPassthroughArgs {
+      override_input: vec![
+        "nixpkgs".into(),
+        "github:NixOS/nixpkgs/nixos-unstable".into(),
+      ],
+      ..Default::default()
+    };
+
+    assert_eq!(args.generate_passthrough_args(), [
+      "--override-input",
+      "nixpkgs",
+      "github:NixOS/nixpkgs/nixos-unstable"
+    ]);
   }
 }


### PR DESCRIPTION
We seem to be missing this compared to nixos-rebuild's default behaviour. For the sake of familiarity, I'm adding it. Depends on #712 