### PR TITLE
nh-clean: don't age out non-result auto-gcroots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ functionality, under the "Removed" section.
   `nh clean all --ask` could delete a live, in-use gcroot on confirmation,
   causing the next `nix store gc` to silently collect an active generation
   ([#722](https://github.com/nix-community/nh/issues/722)).
+  - `nh clean` no longer aborts entirely when a gcroot target lives on a
+    read-only-mounted Nix store or otherwise can't be write-checked for a known,
+    expected reason (`EACCES`, `EROFS`, `EPERM`)..
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `nh clean`'s auto-gcroot handling no longer subjects arbitrary indirect
+  gcroots (e.g., home-manager's `current-home`, or any other tool's "current
+  generation" symlink) to `--keep-since` age-based cleanup. Only roots that
+  structurally look like ephemeral `nix build` result symlinks (`result`,
+  `result-<name>`) are aged out; anything else resolving into `/nix/store` is
+  left untouched unless it becomes orphaned (its target no longer exists),
+  matching real Nix's indirect-gcroot semantics. Previously,
+  `nh clean all --ask` could delete a live, in-use gcroot on confirmation,
+  causing the next `nix store gc` to silently collect an active generation
+  ([#722](https://github.com/nix-community/nh/issues/722)).
+
 ### Removed
 
 ## 4.4.0

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -309,8 +309,8 @@ impl args::CleanMode {
             );
             orphan_gcroots.push(src);
           },
-          Err(Errno::EACCES) => {
-            debug!("dst not writable, skipping");
+          Err(errno @ (Errno::EACCES | Errno::EROFS | Errno::EPERM)) => {
+            debug!(?errno, ?dst, "gcroot target not writable, skipping");
           },
           Err(errno) => {
             bail!(

--- a/crates/nh-clean/src/clean.rs
+++ b/crates/nh-clean/src/clean.rs
@@ -38,6 +38,11 @@ static GENERATION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^(.*)-(\d+)-link$").expect("Failed to compile generation regex")
 });
 
+static RESULT_LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+  #[allow(clippy::expect_used)]
+  Regex::new(r"^result(-.*)?$").expect("Failed to compile result link regex")
+});
+
 const AUTO_GCROOTS_DIR: &str = "/nix/var/nix/gcroots/auto";
 
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -236,11 +241,6 @@ impl args::CleanMode {
           continue;
         }
 
-        if !gcroot_matches_filter(&src, &dst, regexes) {
-          debug!("dst doesn't match any gcroot filter, skipping");
-          continue;
-        }
-
         match faccessat(
           &dirfd,
           &dst,
@@ -249,15 +249,25 @@ impl args::CleanMode {
         ) {
           Ok(()) => {
             if dst.metadata().is_err() {
+              // A live root's target is never aged out. It's only removed once
+              // it is provably dead (which is how Nix's own indirect-gcroot
+              // semantics work.) This check must run for every gcroot, not just
+              // ones matching the age-based cleanup filter below.
               debug!(?dst, "gcroot target already GC'd, tagging for removal");
               gcroots_tagged.push(GcRootTagged {
                 src,
                 dst,
                 tbr: true,
               });
-            } else if args.keep_one
-              && DIRENV_REGEX.is_match(&dst.to_string_lossy())
-            {
+              continue;
+            }
+
+            if !gcroot_matches_filter(&src, &dst, regexes) {
+              debug!("dst doesn't match any gcroot filter, skipping");
+              continue;
+            }
+
+            if args.keep_one && DIRENV_REGEX.is_match(&dst.to_string_lossy()) {
               gcroots_tagged.push(GcRootTagged {
                 src,
                 dst,
@@ -589,11 +599,26 @@ fn gcroot_matches_filter(src: &Path, dst: &Path, regexes: &[&Regex]) -> bool {
   regexes
     .iter()
     .any(|next| next.is_match(&dst.to_string_lossy()))
-    || (is_auto_gcroot_entry(src) && is_nix_store_direct_child(&resolved_dst))
+    || (is_auto_gcroot_entry(src)
+      && is_nix_store_direct_child(&resolved_dst)
+      && is_build_result_link(dst))
 }
 
 fn is_auto_gcroot_entry(path: &Path) -> bool {
   path.starts_with(AUTO_GCROOTS_DIR)
+}
+
+/// Whether `path`'s basename looks like an ephemeral `nix build` result
+/// symlink (`result`, `result-dev`, etc.), as opposed to a live indirect
+/// gcroot such as home-manager's `current-home` or `current-system`. Only
+/// paths matching this are subject to age-based (`--keep-since`) cleanup;
+/// anything else that resolves straight into `/nix/store` is left alone
+/// unless it becomes orphaned.
+fn is_build_result_link(path: &Path) -> bool {
+  path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .is_some_and(|name| RESULT_LINK_REGEX.is_match(name))
 }
 
 fn gcroot_path_to_remove(gcroot: &GcRootTagged) -> &Path {
@@ -667,11 +692,51 @@ mod tests {
   }
 
   #[test]
-  fn gcroot_filter_passes_auto_store_direct_child() {
+  fn gcroot_filter_rejects_auto_store_direct_child_without_result_name() {
+    // A direct-store-child target that isn't reached through a
+    // `result`-shaped path (e.g., a raw store path registered as an
+    // indirect root) is not eligible for age-based cleanup.
     let src = Path::new("/nix/var/nix/gcroots/auto/example");
     let dst = Path::new("/nix/store/abc123zzz-foo-1.0");
     let regexes = [&*DIRENV_REGEX];
-    assert!(gcroot_matches_filter(src, dst, &regexes));
+    assert!(!gcroot_matches_filter(src, dst, &regexes));
+  }
+
+  #[test]
+  fn gcroot_filter_rejects_current_home_shaped_auto_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let link = dir.path().join("current-home");
+    std::os::unix::fs::symlink("/nix/store/abc123zzz-foo-1.0", &link)
+      .expect("symlink");
+
+    let src = Path::new("/nix/var/nix/gcroots/auto/example");
+    let regexes = [&*DIRENV_REGEX];
+    assert!(
+      !gcroot_matches_filter(src, &link, &regexes),
+      "current-home-shaped roots must not be subject to age-based cleanup"
+    );
+  }
+
+  #[test]
+  fn build_result_link_matches_result_and_variants() {
+    assert!(is_build_result_link(Path::new("/home/user/project/result")));
+    assert!(is_build_result_link(Path::new(
+      "/home/user/project/result-dev"
+    )));
+    assert!(is_build_result_link(Path::new(
+      "/home/user/project/result-bin"
+    )));
+  }
+
+  #[test]
+  fn build_result_link_rejects_current_home_and_system() {
+    assert!(!is_build_result_link(Path::new(
+      "/var/lib/foo/current-home"
+    )));
+    assert!(!is_build_result_link(Path::new("/run/current-system")));
+    assert!(!is_build_result_link(Path::new(
+      "/nix/store/abc123zzz-foo-1.0"
+    )));
   }
 
   #[test]
@@ -777,6 +842,25 @@ mod tests {
     assert!(
       link.metadata().is_err(),
       "following broken symlink should fail"
+    );
+  }
+
+  #[test]
+  fn orphaned_current_home_shaped_root_is_still_removable() {
+    // Even though a current-home-shaped root is exempt from age-based cleanup
+    // (also see: gcroot_filter_rejects_current_home_shaped_auto_root), once
+    // its target is actually gone it must still be detected as
+    // broken. This is sorta universal, and filter independent.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("gone-home");
+    let link = dir.path().join("current-home");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    assert!(!is_build_result_link(&link));
+    assert!(
+      link.metadata().is_err(),
+      "broken current-home-shaped symlink must be detected as orphaned \
+       regardless of its name"
     );
   }
 


### PR DESCRIPTION
Somewhat safer handling of gcroots to ensure only certain ephemeral build result symlinks are subject to age-based cleanup. This should prevent "happy" little accidents, i.e., accidental deletion of important indirect gcroots such as those used by Home Manager or system generations.

Change-Id: I5a22370ef52debf4ac3d25426ab281256a6a6964

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
