### PR TITLE
nh-search: search {prs,isssues} using update date instead of creation date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `nh search prs` and `nh search issues` now search pull requests and issues
+  updated in the requested `--days` window instead of only items created in that
+  window.
 - `nh` now properly errors when the provided or stored GitHub token is invalid
   or malformed.
 

--- a/crates/nh-search/src/args.rs
+++ b/crates/nh-search/src/args.rs
@@ -182,7 +182,7 @@ pub struct PlatformsArg {
 
 #[derive(Args, Debug, Clone, Copy)]
 pub struct DaysArg {
-  /// Search GitHub results from the last n days (default: 15).
+  /// Search GitHub results updated in the last n days (default: 15).
   #[arg(
     id = "days",
     short = 'd',

--- a/crates/nh-search/src/github/issues.rs
+++ b/crates/nh-search/src/github/issues.rs
@@ -68,11 +68,9 @@ pub(super) fn search(
   query: &str,
   days: u32,
 ) -> Result<Vec<Issue>> {
-  let date = (Utc::now() - ChronoDuration::days(i64::from(days)))
+  let updated_since = (Utc::now() - ChronoDuration::days(i64::from(days)))
     .to_rfc3339_opts(SecondsFormat::Secs, true);
-  let github_query = format!(
-    "repo:NixOS/nixpkgs {query} type:issue created:>{date} sort:created-desc"
-  );
+  let github_query = search_query(query, &updated_since);
   let data = client.query::<SearchIssuesData>(
     SEARCH_ISSUES_QUERY,
     &json!({
@@ -88,6 +86,13 @@ pub(super) fn search(
     .flatten()
     .map(IssueNode::try_into_issue)
     .collect()
+}
+
+fn search_query(query: &str, updated_since: &str) -> String {
+  format!(
+    "repo:NixOS/nixpkgs {query} type:issue updated:>{updated_since} \
+     sort:updated-desc"
+  )
 }
 
 impl IssueNode {
@@ -114,7 +119,16 @@ mod tests {
   use color_eyre::Result;
   use serde_json::json;
 
-  use super::{IssueNode, IssueState};
+  use super::{IssueNode, IssueState, search_query};
+
+  #[test]
+  fn search_query_uses_recently_updated_issues() {
+    assert_eq!(
+      "repo:NixOS/nixpkgs bug type:issue updated:>2026-07-01T12:00:00Z \
+       sort:updated-desc",
+      search_query("bug", "2026-07-01T12:00:00Z")
+    );
+  }
 
   #[test]
   fn parses_open_issue() -> Result<()> {

--- a/crates/nh-search/src/github/prs.rs
+++ b/crates/nh-search/src/github/prs.rs
@@ -89,11 +89,9 @@ pub(super) fn search(
   query: &str,
   days: u32,
 ) -> Result<Vec<PullRequest>> {
-  let date = (Utc::now() - ChronoDuration::days(i64::from(days)))
+  let updated_since = (Utc::now() - ChronoDuration::days(i64::from(days)))
     .to_rfc3339_opts(SecondsFormat::Secs, true);
-  let github_query = format!(
-    "repo:NixOS/nixpkgs {query} type:pr created:>{date} sort:created-desc"
-  );
+  let github_query = search_query(query, &updated_since);
   let data = client.query::<SearchPullRequestsData>(
     SEARCH_PULL_REQUESTS_QUERY,
     &json!({
@@ -137,6 +135,13 @@ pub fn parse_direct_pr_number(query: &str) -> Option<u64> {
     .flatten()
 }
 
+fn search_query(query: &str, updated_since: &str) -> String {
+  format!(
+    "repo:NixOS/nixpkgs {query} type:pr updated:>{updated_since} \
+     sort:updated-desc"
+  )
+}
+
 impl PullRequestNode {
   fn try_into_pull_request(self) -> Result<PullRequest> {
     let state = parse_state(self.merged, &self.state)?;
@@ -170,7 +175,12 @@ mod tests {
   use color_eyre::Result;
   use serde_json::json;
 
-  use super::{PullRequestNode, PullRequestState, parse_direct_pr_number};
+  use super::{
+    PullRequestNode,
+    PullRequestState,
+    parse_direct_pr_number,
+    search_query,
+  };
 
   #[test]
   fn parses_direct_pr_numbers() {
@@ -178,6 +188,15 @@ mod tests {
     assert_eq!(Some(123), parse_direct_pr_number("#123"));
     assert_eq!(None, parse_direct_pr_number("foo 123"));
     assert_eq!(None, parse_direct_pr_number("#"));
+  }
+
+  #[test]
+  fn search_query_uses_recently_updated_pull_requests() {
+    assert_eq!(
+      "repo:NixOS/nixpkgs hello type:pr updated:>2026-07-01T12:00:00Z \
+       sort:updated-desc",
+      search_query("hello", "2026-07-01T12:00:00Z")
+    );
   }
 
   #[test]

--- a/crates/nh-search/src/issues.rs
+++ b/crates/nh-search/src/issues.rs
@@ -31,7 +31,7 @@ pub fn run(json: bool, args: &args::IssuesArgs) -> Result<()> {
   }
 
   if issues.is_empty() {
-    println!("No issues found for '{query}' in the last {days} days.");
+    println!("No issues found for '{query}' updated in the last {days} days.");
     return Ok(());
   }
 

--- a/crates/nh-search/src/prs.rs
+++ b/crates/nh-search/src/prs.rs
@@ -79,7 +79,7 @@ pub fn run(json: bool, args: &args::PrsArgs) -> Result<()> {
       return Ok(());
     }
   } else if prs.is_empty() {
-    println!("No PRs found for '{query}' in the last {days} days.");
+    println!("No PRs found for '{query}' updated in the last {days} days.");
     return Ok(());
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -230,20 +230,20 @@ options (powered by an Elasticsearch client against search.nixos.org), offline
 search against local [SPAM] databases, and Nixpkgs pull request and issue
 search. All available as `nh search`!
 
-The command exposes three explicit subcommands and a convenient shorthand:
+The command exposes several explicit subcommands and a convenient shorthand:
 
 <!--markdownlint-disable MD013 -->
 
 [found here]: https://github.com/feel-co/spam/actions/workflows/auto-index.yml
 
-| Invocation                                    | What it does                                                                                   |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `nh search <query>`                           | Shorthand; searches packages by default (see `NH_DEFAULT_SEARCH`)                              |
-| `nh search packages <query>`                  | Search Nixpkgs packages via search.nixos.org                                                   |
-| `nh search options [--scope=<SCOPE>] <query>` | Search NixOS/Home Manager options (`--scope`: `nixpkgs`, `home-manager`, `all`)                |
-| `nh search offline --db <PATH> <query>`       | Search a local SPAM database without network access. Generated DBs can be [found here].        |
-| `nh search prs [--days <DAYS>] <query>`       | Search Nixpkgs pull requests and show branch reachability for merged PRs. Defaults to 15 days. |
-| `nh search issues [--days <DAYS>] <query>`    | Search Nixpkgs issues, excluding pull requests. Defaults to 15 days.                           |
+| Invocation                                    | What it does                                                                                                       |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `nh search <query>`                           | Shorthand; searches packages by default (see `NH_DEFAULT_SEARCH`)                                                  |
+| `nh search packages <query>`                  | Search Nixpkgs packages via search.nixos.org                                                                       |
+| `nh search options [--scope=<SCOPE>] <query>` | Search NixOS/Home Manager options (`--scope`: `nixpkgs`, `home-manager`, `all`)                                    |
+| `nh search offline --db <PATH> <query>`       | Search a local SPAM database without network access. Generated DBs can be [found here].                            |
+| `nh search prs [--days <DAYS>] <query>`       | Search Nixpkgs pull requests and show branch reachability for merged PRs. Defaults to updates in the last 15 days. |
+| `nh search issues [--days <DAYS>] <query>`    | Search Nixpkgs issues, excluding pull requests. Defaults to updates in the last 15 days.                           |
 
 <!--markdownlint-enable MD013 -->
 


### PR DESCRIPTION
before:
```
━━ nh
  NH_LOG="" nh search prs tack

No PRs found for 'tack' in the last 15 days.
```
after:
```
━┫3sec 984ms┣━ nh
  NH_LOG="" cargo run search prs tack

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/nh search prs tack`
tack: init at 1.0.0; init module (merged) #533815
   └─ Reachable in: None
papra: 26.4.0 -> 26.5.0 (merged) #531079
   └─ Reachable in: nixpkgs-unstable, nixos-unstable-small, nixos-unstable
stdenv: allow preserving meta fields in derivation (open) #420575
nixos/mpv: import from home-manager (open) #484501
```

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [Xk] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
