### PR TITLE
nh home: detect hostname like home-manager (POSIX + multi-candidate)

### DIFF
--- a/crates/nh-core/src/util.rs
+++ b/crates/nh-core/src/util.rs
@@ -308,6 +308,58 @@ pub fn get_hostname(supplied_hostname: Option<String>) -> Result<String> {
   }
 }
 
+/// Gets the list of candidate hostnames for matching home-manager
+/// configuration attribute names.
+///
+/// Unlike [`get_hostname`], which returns nix-darwin's convention (the
+/// Bonjour `LocalHostName`, dots stripped) so that `nh os` stays aligned
+/// with `darwin-rebuild`, home-manager itself resolves its hostname via the
+/// POSIX `hostname(1)` / `gethostname(2)` call, which preserves dots (e.g.
+/// `joao.palharini`). On macOS these two can differ, so callers that probe
+/// home-manager configuration attribute names (e.g. `nh home`) should try
+/// both.
+///
+/// # Returns
+///
+/// * `Ok(Vec<String>)` with a deduped, ordered list of hostname candidates.
+///
+/// # Errors
+///
+/// Returns an error if the POSIX hostname cannot be retrieved or contains
+/// invalid UTF-8.
+pub fn get_hostname_candidates() -> Result<Vec<String>> {
+  use color_eyre::eyre::Context;
+
+  let mut candidates = Vec::new();
+
+  #[cfg(target_os = "macos")]
+  {
+    use color_eyre::eyre::bail;
+    use system_configuration::{
+      core_foundation::{base::TCFType, string::CFString},
+      sys::dynamic_store_copy_specific::SCDynamicStoreCopyLocalHostName,
+    };
+
+    let ptr = unsafe { SCDynamicStoreCopyLocalHostName(std::ptr::null()) };
+    if ptr.is_null() {
+      bail!("Failed to get hostname, and no hostname supplied");
+    }
+    let name = unsafe { CFString::wrap_under_get_rule(ptr) };
+    candidates.push(name.to_string());
+  }
+
+  let posix_hostname = nix::unistd::gethostname()
+    .context("Failed to get hostname, and no hostname supplied")?
+    .into_string()
+    .map_err(|_| eyre::eyre!("Hostname contains invalid UTF-8"))?;
+
+  if !candidates.contains(&posix_hostname) {
+    candidates.push(posix_hostname);
+  }
+
+  Ok(candidates)
+}
+
 /// Retrieves all enabled experimental features in Nix (cached).
 ///
 /// This function executes the `nix config show experimental-features` command
@@ -513,6 +565,21 @@ mod tests {
   use nh_installable::Installable;
 
   use super::*;
+
+  #[test]
+  fn test_get_hostname_candidates_non_empty_and_deduped() {
+    let candidates =
+      get_hostname_candidates().expect("Failed to get hostname candidates");
+
+    assert!(!candidates.is_empty());
+
+    let unique: HashSet<_> = candidates.iter().collect();
+    assert_eq!(
+      unique.len(),
+      candidates.len(),
+      "hostname candidates should be deduped"
+    );
+  }
 
   #[test]
   fn test_get_build_image_variants_expression() {

--- a/crates/nh-home/src/home.rs
+++ b/crates/nh-home/src/home.rs
@@ -10,7 +10,7 @@ use color_eyre::{
 use nh_core::{
   command::{self, Command, CommandKind, NixCommand},
   update::update,
-  util::get_hostname,
+  util::get_hostname_candidates,
 };
 use nh_diff::print_dix_diff;
 use nh_installable::{CommandContext, Installable};
@@ -371,10 +371,15 @@ where
       if !found_config {
         let username =
           std::env::var("USER").map_err(|_| eyre!("Couldn't get username"))?;
-        let hostname = get_hostname(None)?;
+        let hostnames = get_hostname_candidates()?;
         let mut tried = vec![];
 
-        for attr_name in [format!("{username}@{hostname}"), username] {
+        let attr_candidates = hostnames
+          .iter()
+          .map(|hostname| format!("{username}@{hostname}"))
+          .chain(std::iter::once(username.clone()));
+
+        for attr_name in attr_candidates {
           let func = format!(r#" x: x ? "{attr_name}" "#);
           let check_res = capture_nix_stdout(
             &NixCommand::new(CommandKind::Eval)


### PR DESCRIPTION
## Summary

nix-darwin and home-manager use different hostname conventions, and `nh` only spoke one of them.

- `nh os` / `nh darwin` correctly use macOS's Bonjour `LocalHostName` (via `SCDynamicStoreCopyLocalHostName`), matching what `darwin-rebuild` itself uses (`scutil --get LocalHostName`). This name strips dots, e.g. `joao.palharini` becomes `joaopalharini`.
- home-manager, however, resolves its own hostname via the POSIX `hostname(1)` / `gethostname(2)` call, which preserves dots, and it already probes multiple candidate attribute names (`username@hostname`, then bare `username`).

`nh home`'s automatic configuration detection reused the darwin hostname helper, so on a machine with a dotted local hostname (e.g. `joao.palharini`), it would only ever try `user@joaopalharini` and never match a home-manager flake output keyed `user@joao.palharini`, forcing users to pass `-c/--configuration` explicitly.

## Fix

Adds `nh_core::util::get_hostname_candidates()`, a sibling to the existing `get_hostname()`, that returns a deduped ordered list: on macOS, both the Bonjour name and the POSIX name; elsewhere, just the POSIX name. `nh home`'s `toplevel_for` now iterates `username@hostname` over all candidates (then falls back to bare `username`), reusing the existing per-candidate `nix eval` existence probe and error-aggregation message unchanged.

This is purely additive:

- `nh os` / `nh darwin` are untouched, still single-source `get_hostname`, staying aligned with `darwin-rebuild`.
- No new CLI flags or config; the `-c/--configuration` override still works exactly as before.
- Scoped to the `nh home` automatic-detection path only.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` full workspace, 0 failures, including a new unit test for `get_hostname_candidates` (non-empty, deduped)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets` no new warnings (one pre-existing, unrelated `unused_self` warning in `nh-remote` confirmed present on `master` too)
