### PR TITLE
nh-installable: pass through parameterized flake expressions to Nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ functionality, under the "Removed" section.
   mutable nixpkgs channel. Local `Defined at` links now resolve the ambient
   nixpkgs lookup path offline
   ([#732](https://github.com/nix-community/nh/issues/732)).
+- Parameterized local flake references such as `path:/repo?dir=nix/flakes` and
+  `./nix?submodules=1` are now passed through to Nix instead of being rejected
+  by nh's local path validation
+  ([#733](https://github.com/nix-community/nh/issues/733)).
 - `nh search prs` and `nh search issues` now search pull requests and issues
   updated in the requested `--days` window instead of only items created in that
   window.

--- a/crates/nh-installable/src/lib.rs
+++ b/crates/nh-installable/src/lib.rs
@@ -593,10 +593,14 @@ where
 fn local_flake_reference_path(reference: &str) -> Option<PathBuf> {
   // Only preflight references that are unmistakably filesystem paths. Bare
   // names like `nixpkgs`, plus URL/registry-style refs, stay in Nix's hands.
+  // Parameterized local flake references such as `path:/repo?dir=nix/flakes`
+  // and `./nix?submodules=1` have scheme- and repository-dependent semantics,
+  // so we leave their interpretation to Nix as well.
+  if reference.contains('?') {
+    return None;
+  }
+
   if let Some(path) = reference.strip_prefix("path:") {
-    // Query parameters affect Nix's flakeref, not the local path existence
-    // check. Keep the original reference unchanged for command execution.
-    let path = path.split_once('?').map_or(path, |(path, _)| path);
     return Some(PathBuf::from(path));
   }
 

--- a/crates/nh-installable/src/tests.rs
+++ b/crates/nh-installable/src/tests.rs
@@ -235,20 +235,25 @@ fn test_resolve_or_default_rejects_missing_path_scheme() {
 }
 
 #[test]
-fn test_resolve_or_default_accepts_path_scheme_with_query() {
-  let flake_dir = tempfile::tempdir().unwrap();
-  fs::write(flake_dir.path().join("flake.nix"), "{}").unwrap();
-  let reference = format!("path:{}?lastModified=1", flake_dir.path().display());
-  let installable = Installable::Flake {
-    reference: reference.clone(),
-    attribute: vec![],
-  };
+fn test_resolve_or_default_defers_parameterized_local_flake_refs_to_nix() {
+  let source_dir = tempfile::tempdir().unwrap();
 
-  let resolved = specified(installable)
-    .resolve_or_default(CommandContext::Os)
-    .unwrap();
+  for reference in [
+    format!("path:{}?lastModified=1", source_dir.path().display()),
+    format!("path:{}?dir=nix/flakes", source_dir.path().display()),
+    format!("{}?submodules=1", source_dir.path().display()),
+  ] {
+    let installable = Installable::Flake {
+      reference: reference.clone(),
+      attribute: vec![],
+    };
 
-  assert_eq!(resolved.to_args(), vec![format!("{reference}#")]);
+    let resolved = specified(installable)
+      .resolve_or_default(CommandContext::Os)
+      .unwrap();
+
+    assert_eq!(resolved.to_args(), vec![format!("{reference}#")]);
+  }
 }
 
 #[test]


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
