### PR TITLE
nh-search: fix search speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `nh search` now renders package and option results immediately after the
+  search backend responds instead of blocking while fetching and evaluating a
+  mutable nixpkgs channel. Local `Defined at` links now resolve the ambient
+  nixpkgs lookup path offline
+  ([#732](https://github.com/nix-community/nh/issues/732)).
 - `nh search prs` and `nh search issues` now search pull requests and issues
   updated in the requested `--days` window instead of only items created in that
   window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "spam-db",
- "subprocess",
  "supports-hyperlinks",
  "tempfile",
  "textwrap",

--- a/crates/nh-search/Cargo.toml
+++ b/crates/nh-search/Cargo.toml
@@ -20,7 +20,6 @@ secrecy.workspace             = true
 serde.workspace               = true
 serde_json.workspace          = true
 spam-db.workspace             = true
-subprocess.workspace          = true
 supports-hyperlinks.workspace = true
 tempfile.workspace            = true
 textwrap.workspace            = true

--- a/crates/nh-search/src/render/common.rs
+++ b/crates/nh-search/src/render/common.rs
@@ -1,8 +1,7 @@
-use std::sync::OnceLock;
+use std::{path::PathBuf, sync::OnceLock};
 
 use nh_core::command::{CommandKind, NixCommand};
 use regex::Regex;
-use subprocess::Redirection;
 use tracing::warn;
 
 static HYPERLINKS_SUPPORTED: OnceLock<bool> = OnceLock::new();
@@ -65,33 +64,54 @@ pub(super) fn strip_html(html: &str) -> String {
   re.replace_all(html, "").trim().to_string()
 }
 
-pub(super) fn resolve_nixpkgs_path(channel: &str) -> String {
-  let flake_ref = if channel == "nixos-unstable" {
-    "github:NixOS/nixpkgs/nixos-unstable".to_string()
-  } else if channel.starts_with("nixos-") {
-    format!("github:NixOS/nixpkgs/{channel}")
-  } else {
-    "nixpkgs".to_string()
-  };
+/// Resolve the ambient nixpkgs lookup path without fetching a mutable channel.
+///
+/// This path only backs the local `file://` link. The channel-specific source
+/// link is rendered separately, so failure here should not block search output.
+pub(super) fn resolve_nixpkgs_path() -> Option<PathBuf> {
+  let output = nixpkgs_path_command().output().ok()?;
+  if !output.status.success() {
+    return None;
+  }
 
-  let flake_path = format!("{flake_ref}#path");
-  capture_nix_eval(&["--raw", &flake_path])
-    .or_else(|| capture_nix_eval(&["-f", "<nixpkgs>", "path"]))
-    .unwrap_or_default()
+  let path = std::str::from_utf8(&output.stdout).ok()?.trim();
+  if path.is_empty() {
+    None
+  } else {
+    Some(PathBuf::from(path))
+  }
 }
 
-fn capture_nix_eval(args: &[&str]) -> Option<String> {
-  let capture = NixCommand::new(CommandKind::Eval)
-    .args(args)
-    .to_exec()
-    .stderr(Redirection::None)
-    .stdout(Redirection::Pipe)
-    .capture()
-    .ok()?;
+fn nixpkgs_path_command() -> NixCommand {
+  NixCommand::new(CommandKind::Eval).impure(true).args([
+    "--offline",
+    "--raw",
+    "--expr",
+    "toString <nixpkgs>",
+  ])
+}
 
-  capture
-    .exit_status
-    .success()
-    .then(|| capture.stdout_str().trim().to_string())
-    .filter(|path| !path.is_empty())
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn nixpkgs_path_lookup_is_local_and_offline() {
+    let argv = nixpkgs_path_command().argv();
+
+    assert_eq!(argv, [
+      "nix",
+      "eval",
+      "--impure",
+      "--offline",
+      "--raw",
+      "--expr",
+      "toString <nixpkgs>"
+    ]);
+    assert!(
+      !argv
+        .iter()
+        .any(|arg| arg.to_string_lossy().contains("github:"))
+    );
+  }
 }

--- a/crates/nh-search/src/render/options.rs
+++ b/crates/nh-search/src/render/options.rs
@@ -5,7 +5,7 @@ use super::common;
 use crate::types::OptionSearchResult;
 
 pub fn print(channel: &str, documents: &[OptionSearchResult]) {
-  let nixpkgs_path = common::resolve_nixpkgs_path(channel);
+  let nixpkgs_path = common::resolve_nixpkgs_path();
   debug!("nixpkgs_path: {:?}", nixpkgs_path);
 
   for elem in documents.iter().rev() {
@@ -38,11 +38,11 @@ pub fn print(channel: &str, documents: &[OptionSearchResult]) {
       let is_home_manager = elem.r#type == "home-manager-option";
       let filepath = source.split(':').next().unwrap_or(source);
 
-      if !is_home_manager && !nixpkgs_path.is_empty() {
+      if !is_home_manager && let Some(nixpkgs_path) = &nixpkgs_path {
         common::print_field_hyperlink(
           "Defined at",
           filepath,
-          &format!("file://{nixpkgs_path}/{filepath}"),
+          &format!("file://{}/{filepath}", nixpkgs_path.display()),
         );
       }
 

--- a/crates/nh-search/src/render/packages.rs
+++ b/crates/nh-search/src/render/packages.rs
@@ -9,7 +9,7 @@ pub fn print(
   platforms: bool,
   documents: &[PackageSearchResult],
 ) {
-  let nixpkgs_path = common::resolve_nixpkgs_path(channel);
+  let nixpkgs_path = common::resolve_nixpkgs_path();
   debug!("nixpkgs_path: {:?}", nixpkgs_path);
 
   for elem in documents.iter().rev() {
@@ -39,11 +39,11 @@ pub fn print(
     if let Some(package_position) = &elem.package_position {
       match package_position.split(':').next() {
         Some(position) => {
-          if !nixpkgs_path.is_empty() {
+          if let Some(nixpkgs_path) = &nixpkgs_path {
             common::print_field_hyperlink(
               "Defined at",
               position,
-              &format!("file://{nixpkgs_path}/{position}"),
+              &format!("file://{}/{position}", nixpkgs_path.display()),
             );
           }
 


### PR DESCRIPTION
speeeeeeeeeeeeeeeeeeeeeeeeeeeeeeed again.

added a regression test to make sure we don't do this again. :)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
