### PR TITLE
fix: fix `nh darwin` producing `.cache` in cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ functionality, under the "Removed" section.
 - `nh` now properly errors when the provided or stored GitHub token is invalid
   or malformed.
 - `nh darwin` now properly caches in root user's home directory on macOS instead
-  of in working directory ([#739](https://github.com/nix-community/nh/issues/739))
+  of in working directory
+  ([#739](https://github.com/nix-community/nh/issues/739))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ functionality, under the "Removed" section.
   window.
 - `nh` now properly errors when the provided or stored GitHub token is invalid
   or malformed.
-- `nh darwin` now properly caches in MacOS home directory for root instead of in
-  working directory
+- `nh darwin` now properly caches in root user's home directory on macOS instead
+  of in working directory ([#739](https://github.com/nix-community/nh/issues/739))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ functionality, under the "Removed" section.
   window.
 - `nh` now properly errors when the provided or stored GitHub token is invalid
   or malformed.
+- `nh darwin` now properly caches in MacOS home directory for root instead of in
+  working directory
 
 ### Removed
 

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -543,12 +543,12 @@ impl Command {
         .insert("HOME".to_string(), EnvAction::Set(home));
     }
 
-    // INFO: Setting HOME to "" for macos
+    // INFO: Set HOME to proper root-owned directory for macos
     // ref: https://github.com/NixOS/nix/blob/d5d7ca01b3dcf48f43819012c580cfb57cb08e47/src/libutil/unix/users.cc#L52
     if self.elevate.is_some() && cfg!(target_os = "macos") {
       self
         .env_vars
-        .insert("HOME".to_string(), EnvAction::Set(String::new()));
+        .insert("HOME".to_string(), EnvAction::Set("/var/root".to_string()));
     }
 
     // Preserve all variables in PRESERVE_ENV if present


### PR DESCRIPTION
Fix #739 by mirroring `darwin-rebuild` implementation (https://github.com/nix-darwin/nix-darwin/blob/15abb8c98f336cd8bd840d71059adebabe60bf04/pkgs/nix-tools/darwin-rebuild.sh#L5)
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
