### PR TITLE
treewide: add NH_ASK environment variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ functionality, under the "Removed" section.
 
 ### Added
 
+- `nh` now supports the boolean `NH_ASK` environment variable as the environment
+  counterpart to `--ask`. When set, applicable commands behave as if `--ask` had
+  been passed explicitly, avoiding the need to specify it on every invocation
+  ([#418](https://github.com/nix-community/nh/issues/418)).
 - `nh search options` can now search nix-darwin options via a new
   `--scope=nix-darwin` value. The default `--scope=all` now searches nix-darwin
   options in addition to NixOS, modular service, and home-manager options.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "nh-home",
  "nh-nixos",
  "nh-search",
+ "serial_test",
  "tracing",
  "tracing-subscriber",
  "yansi",

--- a/crates/nh-clean/src/args.rs
+++ b/crates/nh-clean/src/args.rs
@@ -37,7 +37,12 @@ pub struct CleanArgs {
   pub dry: bool,
 
   /// Ask for confirmation
-  #[arg(long, short)]
+  #[arg(
+    long,
+    short,
+    env = "NH_ASK",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub ask: bool,
 
   /// Don't run nix store --gc

--- a/crates/nh-core/src/args.rs
+++ b/crates/nh-core/src/args.rs
@@ -11,7 +11,12 @@ pub struct CommonRebuildArgs {
   pub dry: bool,
 
   /// Ask for confirmation
-  #[arg(long, short)]
+  #[arg(
+    long,
+    short,
+    env = "NH_ASK",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub ask: bool,
 
   #[command(flatten)]

--- a/crates/nh-nixos/src/args.rs
+++ b/crates/nh-nixos/src/args.rs
@@ -213,7 +213,12 @@ pub struct OsRollbackArgs {
   pub dry: bool,
 
   /// Ask for confirmation
-  #[arg(long, short)]
+  #[arg(
+    long,
+    short,
+    env = "NH_ASK",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub ask: bool,
 
   /// Explicitly select some specialisation
@@ -245,7 +250,12 @@ pub struct CommonRebuildArgs {
   pub dry: bool,
 
   /// Ask for confirmation
-  #[arg(long, short)]
+  #[arg(
+    long,
+    short,
+    env = "NH_ASK",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub ask: bool,
 
   #[command(flatten)]

--- a/crates/nh/Cargo.toml
+++ b/crates/nh/Cargo.toml
@@ -25,5 +25,8 @@ tracing.workspace             = true
 tracing-subscriber.workspace  = true
 yansi.workspace               = true
 
+[dev-dependencies]
+serial_test.workspace = true
+
 [lints]
 workspace = true

--- a/crates/nh/src/interface.rs
+++ b/crates/nh/src/interface.rs
@@ -101,3 +101,68 @@ impl NHCommand {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use std::{env, ffi::OsString};
+
+  use clap::{Parser, error::ErrorKind};
+  use nh_clean::args::CleanMode;
+  use serial_test::serial;
+
+  use super::{Main, NHCommand};
+
+  struct EnvGuard(Option<OsString>);
+
+  impl EnvGuard {
+    fn new() -> Self {
+      Self(env::var_os("NH_ASK"))
+    }
+  }
+
+  impl Drop for EnvGuard {
+    fn drop(&mut self) {
+      unsafe {
+        match &self.0 {
+          Some(value) => env::set_var("NH_ASK", value),
+          None => env::remove_var("NH_ASK"),
+        }
+      }
+    }
+  }
+
+  #[test]
+  #[serial]
+  fn nh_ask_parses_boolish_environment_values() -> clap::error::Result<()> {
+    let _guard = EnvGuard::new();
+
+    for (value, expected) in
+      [("1", true), ("true", true), ("0", false), ("false", false)]
+    {
+      unsafe {
+        env::set_var("NH_ASK", value);
+      }
+      let parsed = Main::try_parse_from(["nh", "clean", "all"])?;
+      let ask = match parsed.command {
+        NHCommand::Clean(proxy) => {
+          match proxy.command {
+            CleanMode::All(args) => Some(args.ask),
+            _ => None,
+          }
+        },
+        _ => None,
+      };
+      assert_eq!(ask, Some(expected));
+    }
+
+    unsafe {
+      env::set_var("NH_ASK", "invalid");
+    }
+    assert!(matches!(
+      Main::try_parse_from(["nh", "clean", "all"]),
+      Err(error) if error.kind() == ErrorKind::ValueValidation
+    ));
+
+    Ok(())
+  }
+}

--- a/crates/xtask/src/man.rs
+++ b/crates/xtask/src/man.rs
@@ -19,6 +19,12 @@ const ENVIRONMENT: &[Entry] = &[
      or running in constrained build environments.",
   ),
   (
+    "NH_ASK",
+    "When set to a truthy value such as 1, true, yes, or on, asks for \
+     confirmation before applying supported operations. Falsy values such as \
+     0, false, no, or off disable it. Equivalent to --ask.",
+  ),
+  (
     "NH_FLAKE",
     "Preferred path/reference to a directory containing your flake.nix used \
      by NH when running flake-based commands. Historically FLAKE was used; NH \

--- a/docs/README.md
+++ b/docs/README.md
@@ -378,6 +378,11 @@ the common variables that you may encounter or choose to employ are as follows:
 
 ### NH Specific
 
+- `NH_ASK`
+  - When set to a truthy value such as `1`, `true`, `yes`, or `on`, asks for
+    confirmation before applying supported operations. Falsy values such as `0`,
+    `false`, `no`, or `off` disable it. Equivalent to `--ask`.
+
 - `NH_NO_CHECKS`
   - When set (any non-empty value), skips startup checks such as Nix version and
     experimental feature validation. Useful for generating completions or


### PR DESCRIPTION
Closes https://github.com/nix-community/nh/issues/418.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [X] I have read and understood the [contribution guidelines]
- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- Style and consistency
  - [X] I ran **`nix fmt`** to format my Nix code
  - [X] I ran **`cargo fmt`** to format my Rust code
  - [X] I have added appropriate documentation to new code
  - [X] My changes are consistent with the rest of the codebase
- Correctness
  - [X] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [X] My code includes comments in particularly complex areas to explain the
        logic
  - [X] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
