### PR TITLE
treewide: add beautifully formatted activation logs for darwin and home-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ functionality, under the "Removed" section.
 
 ### Added
 
-- `nh darwin switch`, `nh home switch`, and `nh os switch` now feature beautifully formatted and summarized activation logs by default. Homebrew, Home Manager, and Darwin activation steps are summarized automatically into concise blocks.
-
-
+- `nh darwin switch`, `nh home switch`, and `nh os switch` now feature
+  beautifully formatted and summarized activation logs by default. Homebrew,
+  Home Manager, and Darwin activation steps are summarized automatically into
+  concise blocks.
 
 ## 4.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ be put in the "Changed" section or, if it's just to remove code or
 functionality, under the "Removed" section.
 -->
 
+## Unreleased
+
+### Added
+
+- `nh darwin switch`, `nh home switch`, and `nh os switch` now feature beautifully formatted and summarized activation logs by default. Homebrew, Home Manager, and Darwin activation steps are summarized automatically into concise blocks.
+
+
+
 ## 4.4.2
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "which",
+ "yansi",
 ]
 
 [[package]]

--- a/crates/nh-core/Cargo.toml
+++ b/crates/nh-core/Cargo.toml
@@ -24,7 +24,7 @@ subprocess.workspace     = true
 thiserror.workspace      = true
 tracing.workspace        = true
 which.workspace          = true
-yansi.workspace = true
+yansi.workspace          = true
 
 [dev-dependencies]
 proptest.workspace    = true

--- a/crates/nh-core/Cargo.toml
+++ b/crates/nh-core/Cargo.toml
@@ -24,6 +24,7 @@ subprocess.workspace     = true
 thiserror.workspace      = true
 tracing.workspace        = true
 which.workspace          = true
+yansi.workspace = true
 
 [dev-dependencies]
 proptest.workspace    = true

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -407,6 +407,7 @@ pub struct Command {
   elevate:     Option<ElevationStrategy>,
   ssh:         Option<String>,
   show_output: bool,
+  pretty:      bool,
   env_vars:    HashMap<String, EnvAction>,
 }
 
@@ -420,6 +421,7 @@ impl Command {
       elevate:     None,
       ssh:         None,
       show_output: false,
+      pretty:      false,
       env_vars:    HashMap::new(),
     }
   }
@@ -442,6 +444,12 @@ impl Command {
   #[must_use]
   pub const fn show_output(mut self, show_output: bool) -> Self {
     self.show_output = show_output;
+    self
+  }
+
+  #[must_use]
+  pub const fn pretty(mut self, pretty: bool) -> Self {
+    self.pretty = pretty;
     self
   }
 
@@ -857,15 +865,19 @@ impl Command {
     };
 
     // Configure output redirection based on show_output setting
-    let cmd = ssh_wrap(
-      if self.show_output {
-        cmd.stderr(Redirection::Merge)
-      } else {
-        cmd.stderr(Redirection::None).stdout(Redirection::None)
-      },
-      self.ssh.as_deref(),
-      sudo_password.as_ref(),
-    );
+    let cmd = if self.show_output && self.pretty {
+      cmd.stderr(Redirection::Merge).stdout(Redirection::Pipe)
+    } else {
+      ssh_wrap(
+        if self.show_output {
+          cmd.stderr(Redirection::Merge)
+        } else {
+          cmd.stderr(Redirection::None).stdout(Redirection::None)
+        },
+        self.ssh.as_deref(),
+        sudo_password.as_ref(),
+      )
+    };
 
     if let Some(m) = &self.message {
       info!("{m}");
@@ -881,6 +893,10 @@ impl Command {
       .message
       .clone()
       .unwrap_or_else(|| "Command failed".to_string());
+
+    if self.show_output && self.pretty {
+      return crate::format::run_pretty(cmd).wrap_err(msg);
+    }
 
     if self.show_output {
       let exit_status = cmd.join().wrap_err(msg.clone())?;

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -867,17 +867,13 @@ impl Command {
     // Configure output redirection based on show_output setting
     let cmd = if self.show_output && self.pretty {
       cmd.stderr(Redirection::Merge).stdout(Redirection::Pipe)
+    } else if self.show_output {
+      cmd.stderr(Redirection::Merge)
     } else {
-      ssh_wrap(
-        if self.show_output {
-          cmd.stderr(Redirection::Merge)
-        } else {
-          cmd.stderr(Redirection::None).stdout(Redirection::None)
-        },
-        self.ssh.as_deref(),
-        sudo_password.as_ref(),
-      )
+      cmd.stderr(Redirection::None).stdout(Redirection::None)
     };
+
+    let cmd = ssh_wrap(cmd, self.ssh.as_deref(), sudo_password.as_ref());
 
     if let Some(m) = &self.message {
       info!("{m}");

--- a/crates/nh-core/src/format.rs
+++ b/crates/nh-core/src/format.rs
@@ -1,0 +1,298 @@
+use std::io::{BufRead, BufReader, Write};
+
+use subprocess::Exec;
+use yansi::Paint;
+
+use crate::ui::*;
+
+pub enum LogLine {
+  HomebrewUsing(String),
+  HomebrewInstalling(String),
+  HomebrewUpgrading(String),
+  HomebrewComplete(usize),
+  HomeManagerActivating(String),
+  DarwinInfo(String),
+  DarwinSuccess(String),
+  SectionHeader(String),
+  FlakeInputUpdating(String),
+  Warning(String),
+  Other(String),
+}
+
+pub fn process_line(line: &str) -> LogLine {
+  let line = line.trim();
+  if let Some(dep) = line.strip_prefix("Using ") {
+    return LogLine::HomebrewUsing(dep.to_string());
+  }
+  if let Some(dep) = line.strip_prefix("Installing ") {
+    return LogLine::HomebrewInstalling(dep.to_string());
+  }
+  if let Some(dep) = line.strip_prefix("Upgrading ") {
+    return LogLine::HomebrewUpgrading(dep.to_string());
+  }
+  if let Some(caps) = line.strip_prefix("`brew bundle` complete! ") {
+    if let Some(count_str) = caps.split_whitespace().next() {
+      if let Ok(count) = count_str.parse::<usize>() {
+        return LogLine::HomebrewComplete(count);
+      }
+    }
+  }
+  if let Some(caps) = line.strip_prefix("Homebrew Bundle complete! ") {
+    if let Some(count_str) = caps.split_whitespace().next() {
+      if let Ok(count) = count_str.parse::<usize>() {
+        return LogLine::HomebrewComplete(count);
+      }
+    }
+  }
+  if let Some(input) = line.strip_prefix("updating input '") {
+    let input = input.trim_end_matches('\'');
+    return LogLine::FlakeInputUpdating(input.to_string());
+  }
+  if let Some(module) = line.strip_prefix("Activating ") {
+    return LogLine::HomeManagerActivating(module.to_string());
+  }
+  if let Some(msg) = line.strip_prefix("✓ ").or_else(|| line.strip_prefix("✔ "))
+  {
+    if msg.contains("Error:") || msg.contains("failed") {
+      return LogLine::Warning(msg.to_string());
+    }
+    return LogLine::DarwinSuccess(msg.to_string());
+  }
+  if let Some(section) = line.strip_prefix("➜ ") {
+    return LogLine::SectionHeader(section.to_string());
+  }
+  if let Some(info) = line.strip_prefix("ℹ️ ") {
+    return LogLine::DarwinInfo(info.to_string());
+  }
+  if let Some(warn) = line.strip_prefix("Warning: ") {
+    return LogLine::Warning(warn.to_string());
+  }
+  if line.contains("━━━") || line.contains("━━━━") {
+    let content = line.trim_matches('━').trim();
+    if !content.is_empty() {
+      return LogLine::DarwinInfo(content.to_string());
+    }
+  }
+
+  LogLine::Other(line.to_string())
+}
+
+#[derive(Default)]
+pub struct ActivationState {
+  brew_using_count: usize,
+  brew_installed:   Vec<String>,
+  brew_upgraded:    Vec<String>,
+  brew_missing:     usize,
+  hm_count:         usize,
+  darwin_success:   usize,
+  flake_updates:    usize,
+  last_info:        Option<String>,
+}
+
+pub fn run_pretty(exec: Exec) -> color_eyre::Result<()> {
+  let mut popen = exec.start()?;
+  let stdout = popen
+    .stdout
+    .take()
+    .ok_or_else(|| color_eyre::eyre::eyre!("Failed to capture stdout"))?;
+  let reader = BufReader::new(stdout);
+  let mut state = ActivationState::default();
+
+  for line_result in reader.lines() {
+    let line = line_result?;
+    if line.trim().is_empty() {
+      continue;
+    }
+
+    match process_line(&line) {
+      LogLine::HomebrewUsing(_) => {
+        // Already-installed deps are the common case and noisy. Just count
+        // them; they'll appear in the summary as "working fine: N".
+        state.brew_using_count += 1;
+      },
+      LogLine::HomebrewInstalling(name) => {
+        println!(
+          "  {} installing {}",
+          Paint::new(ICON_SUCCESS).fg(GREEN).bold(),
+          Paint::new(&name).bold()
+        );
+        state.brew_installed.push(name);
+      },
+      LogLine::HomebrewUpgrading(name) => {
+        println!(
+          "  {} upgrading {}",
+          Paint::new(ICON_ARROW).fg(BLUE).bold(),
+          Paint::new(&name).bold()
+        );
+        state.brew_upgraded.push(name);
+      },
+      LogLine::HomebrewComplete(count) => {
+        // Per-package install/upgrade lines were already printed above; here
+        // just confirm the bundle finished and show the headline numbers.
+        let changed = state.brew_installed.len() + state.brew_upgraded.len();
+        if count == 0 {
+          // Do nothing
+        } else if changed == 0 {
+          println!(
+            "  {} Homebrew: {} dependencies, all up to date",
+            Paint::new(ICON_SUCCESS).fg(GREEN),
+            count
+          );
+        } else {
+          println!(
+            "  {} Homebrew: {} dependencies — {} installed, {} upgraded",
+            Paint::new(ICON_SUCCESS).fg(GREEN),
+            count,
+            Paint::new(state.brew_installed.len()).fg(GREEN).bold(),
+            Paint::new(state.brew_upgraded.len()).fg(BLUE).bold()
+          );
+        }
+      },
+      LogLine::HomeManagerActivating(_) => {
+        state.hm_count += 1;
+        print!(
+          "\r\x1b[2K  {} Home-Manager: {} modules activated",
+          Paint::new(ICON_INFO).fg(BLUE),
+          state.hm_count
+        );
+        let _ = std::io::stdout().flush();
+      },
+      LogLine::FlakeInputUpdating(_) => {
+        state.flake_updates += 1;
+        print!(
+          "\r\x1b[2K  {} Flake: {} inputs updated",
+          Paint::new(ICON_INFO).fg(BLUE),
+          state.flake_updates
+        );
+        let _ = std::io::stdout().flush();
+      },
+      LogLine::DarwinInfo(info) => {
+        if state.last_info.as_ref() != Some(&info) {
+          println!("\n{} {}", Paint::new(ICON_ARROW).fg(PURPLE).bold(), info);
+          state.last_info = Some(info);
+        }
+      },
+      LogLine::DarwinSuccess(msg) => {
+        state.darwin_success += 1;
+        println!("\r\x1b[2K  {} {}", Paint::new(ICON_SUCCESS).fg(GREEN), msg);
+      },
+      LogLine::SectionHeader(section) => {
+        println!(
+          "\n{} {}",
+          Paint::new(ICON_ARROW).fg(PURPLE).bold(),
+          section.trim()
+        );
+      },
+      LogLine::Warning(warn) => {
+        if warn.contains("not installed") {
+          state.brew_missing += 1;
+        }
+        println!(
+          "\r\x1b[2K  {} Warning: {}",
+          Paint::new(ICON_WARNING).fg(YELLOW),
+          warn
+        );
+      },
+      LogLine::Other(other) => {
+        if other.contains("Starting Home Manager activation") {
+          println!("\r\x1b[2K");
+        } else if other.contains("Error:") || other.contains("failed") {
+          println!(
+            "\r\x1b[2K  {} {}",
+            Paint::new(ICON_WARNING).fg(RED),
+            Paint::new(other).fg(RED)
+          );
+        } else if !other.is_empty() {
+          println!("\r\x1b[2K  {}", Paint::new(other).dim());
+        }
+      },
+    }
+  }
+
+  let status = popen.wait()?;
+  if !status.success() {
+    return Err(color_eyre::eyre::eyre!(
+      "Activation failed with status {:?}",
+      status
+    ));
+  }
+
+  // Print a final summary at the end
+  println!(
+    "\n{} Activation Summary",
+    Paint::new(ICON_SUCCESS).fg(GREEN).bold()
+  );
+  if !state.brew_installed.is_empty()
+    || !state.brew_upgraded.is_empty()
+    || state.brew_using_count > 0
+    || state.brew_missing > 0
+  {
+    println!("  {} Homebrew", Paint::new(ICON_ARROW).fg(PURPLE));
+    if !state.brew_installed.is_empty() {
+      println!(
+        "    {} installed ({}): {}",
+        Paint::new(ICON_SUCCESS).fg(GREEN),
+        Paint::new(state.brew_installed.len()).bold(),
+        Paint::new(state.brew_installed.join(", ")).bold()
+      );
+    }
+    if !state.brew_upgraded.is_empty() {
+      println!(
+        "    {} upgraded  ({}): {}",
+        Paint::new(ICON_ARROW).fg(BLUE),
+        Paint::new(state.brew_upgraded.len()).bold(),
+        Paint::new(state.brew_upgraded.join(", ")).bold()
+      );
+    }
+    if state.brew_using_count > 0 {
+      println!(
+        "    {} working fine: {}",
+        Paint::new(ICON_BULLET).fg(GREY),
+        Paint::new(state.brew_using_count).dim()
+      );
+    }
+    if state.brew_missing > 0 {
+      println!(
+        "    {} missing: {}",
+        Paint::new(ICON_WARNING).fg(YELLOW),
+        Paint::new(state.brew_missing).fg(YELLOW).bold()
+      );
+    }
+  }
+  if state.hm_count > 0 {
+    println!(
+      "  {} Home Manager: {} modules activated",
+      Paint::new(ICON_ARROW).fg(PURPLE),
+      state.hm_count
+    );
+  }
+  if state.darwin_success > 0 {
+    println!(
+      "  {} Darwin: {} system settings applied",
+      Paint::new(ICON_ARROW).fg(PURPLE),
+      state.darwin_success
+    );
+  }
+  if state.flake_updates > 0 {
+    println!(
+      "  {} Flake: {} inputs updated",
+      Paint::new(ICON_ARROW).fg(PURPLE),
+      state.flake_updates
+    );
+  }
+
+  if state.brew_installed.is_empty()
+    && state.brew_upgraded.is_empty()
+    && state.brew_missing == 0
+    && state.hm_count == 0
+    && state.darwin_success == 0
+    && state.flake_updates == 0
+  {
+    println!(
+      "  {} Configuration is already up to date",
+      Paint::new(ICON_SUCCESS).fg(GREEN)
+    );
+  }
+
+  Ok(())
+}

--- a/crates/nh-core/src/format.rs
+++ b/crates/nh-core/src/format.rs
@@ -3,7 +3,19 @@ use std::io::{BufRead, BufReader, Write};
 use subprocess::Exec;
 use yansi::Paint;
 
-use crate::ui::*;
+use crate::ui::{
+  BLUE,
+  GREEN,
+  GREY,
+  ICON_ARROW,
+  ICON_BULLET,
+  ICON_INFO,
+  ICON_SUCCESS,
+  ICON_WARNING,
+  PURPLE,
+  RED,
+  YELLOW,
+};
 
 pub enum LogLine {
   HomebrewUsing(String),
@@ -19,6 +31,7 @@ pub enum LogLine {
   Other(String),
 }
 
+#[must_use]
 pub fn process_line(line: &str) -> LogLine {
   let line = line.trim();
   if let Some(dep) = line.strip_prefix("Using ") {
@@ -30,19 +43,17 @@ pub fn process_line(line: &str) -> LogLine {
   if let Some(dep) = line.strip_prefix("Upgrading ") {
     return LogLine::HomebrewUpgrading(dep.to_string());
   }
-  if let Some(caps) = line.strip_prefix("`brew bundle` complete! ") {
-    if let Some(count_str) = caps.split_whitespace().next() {
-      if let Ok(count) = count_str.parse::<usize>() {
-        return LogLine::HomebrewComplete(count);
-      }
-    }
+  if let Some(caps) = line.strip_prefix("`brew bundle` complete! ")
+    && let Some(count_str) = caps.split_whitespace().next()
+    && let Ok(count) = count_str.parse::<usize>()
+  {
+    return LogLine::HomebrewComplete(count);
   }
-  if let Some(caps) = line.strip_prefix("Homebrew Bundle complete! ") {
-    if let Some(count_str) = caps.split_whitespace().next() {
-      if let Ok(count) = count_str.parse::<usize>() {
-        return LogLine::HomebrewComplete(count);
-      }
-    }
+  if let Some(caps) = line.strip_prefix("Homebrew Bundle complete! ")
+    && let Some(count_str) = caps.split_whitespace().next()
+    && let Ok(count) = count_str.parse::<usize>()
+  {
+    return LogLine::HomebrewComplete(count);
   }
   if let Some(input) = line.strip_prefix("updating input '") {
     let input = input.trim_end_matches('\'');
@@ -89,6 +100,7 @@ pub struct ActivationState {
   last_info:        Option<String>,
 }
 
+#[allow(clippy::missing_errors_doc)]
 pub fn run_pretty(exec: Exec) -> color_eyre::Result<()> {
   let mut popen = exec.start()?;
   let stdout = popen

--- a/crates/nh-core/src/lib.rs
+++ b/crates/nh-core/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod args;
 pub mod checks;
 pub mod command;
+pub mod format;
 pub mod progress;
+pub mod ui;
 pub mod update;
 pub mod util;
 

--- a/crates/nh-core/src/ui.rs
+++ b/crates/nh-core/src/ui.rs
@@ -20,6 +20,7 @@ pub const ICON_DIVIDER: &str = "─";
 /// Render a byte count as a colored, human-readable size:
 /// green for KB, yellow for MB, magenta-bold for GB.
 #[must_use]
+#[allow(clippy::cast_precision_loss)]
 pub fn colored_size(bytes: u64) -> String {
   let kb = bytes as f64 / 1024.0;
   let mb = kb / 1024.0;

--- a/crates/nh-core/src/ui.rs
+++ b/crates/nh-core/src/ui.rs
@@ -1,0 +1,63 @@
+use yansi::{Color, Paint};
+
+pub const PURPLE: Color = Color::Magenta;
+pub const BLUE: Color = Color::Blue;
+pub const GREEN: Color = Color::Green;
+pub const YELLOW: Color = Color::Yellow;
+pub const RED: Color = Color::Red;
+pub const CYAN: Color = Color::Cyan;
+pub const GREY: Color = Color::Fixed(244);
+
+pub const ICON_ARROW: &str = "➜";
+pub const ICON_SUCCESS: &str = "✔";
+pub const ICON_DRY_RUN: &str = "→";
+pub const ICON_INFO: &str = "ℹ";
+pub const ICON_WARNING: &str = "◎";
+pub const ICON_SKIP: &str = "·";
+pub const ICON_BULLET: &str = "•";
+pub const ICON_DIVIDER: &str = "─";
+
+/// Render a byte count as a colored, human-readable size:
+/// green for KB, yellow for MB, magenta-bold for GB.
+#[must_use]
+pub fn colored_size(bytes: u64) -> String {
+  let kb = bytes as f64 / 1024.0;
+  let mb = kb / 1024.0;
+  let gb = mb / 1024.0;
+
+  if gb >= 1.0 {
+    Paint::new(format!("{gb:.2} GB"))
+      .fg(PURPLE)
+      .bold()
+      .to_string()
+  } else if mb >= 1.0 {
+    Paint::new(format!("{mb:.2} MB")).fg(YELLOW).to_string()
+  } else if kb >= 1.0 {
+    Paint::new(format!("{kb:.2} KB")).fg(GREEN).to_string()
+  } else {
+    Paint::new(format!("{bytes} B")).fg(GREEN).dim().to_string()
+  }
+}
+
+/// Render a horizontal divider line of the given width.
+#[must_use]
+pub fn divider(width: usize) -> String {
+  Paint::new(ICON_DIVIDER.repeat(width)).fg(GREY).to_string()
+}
+
+/// Available (free) disk space in bytes for the filesystem containing `path`.
+/// Returns None if statvfs is unsupported or fails.
+#[cfg(unix)]
+#[must_use]
+pub fn available_space_bytes(path: &str) -> Option<u64> {
+  use std::path::Path;
+  nix::sys::statvfs::statvfs(Path::new(path))
+    .ok()
+    .map(|s| u64::from(s.blocks_available()) * s.fragment_size())
+}
+
+#[cfg(not(unix))]
+#[must_use]
+pub fn available_space_bytes(_path: &str) -> Option<u64> {
+  None
+}

--- a/crates/nh-darwin/src/args.rs
+++ b/crates/nh-darwin/src/args.rs
@@ -72,7 +72,15 @@ pub struct DarwinRebuildArgs {
   pub bypass_root_check: bool,
 
   /// Show activation logs
-  #[arg(long, env = "NH_SHOW_ACTIVATION_LOGS", value_parser = clap::builder::BoolishValueParser::new())]
+  #[arg(
+    long,
+    env = "NH_SHOW_ACTIVATION_LOGS",
+    default_value_t = true,
+    action = clap::ArgAction::Set,
+    num_args = 0..=1,
+    default_missing_value = "true",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub show_activation_logs: bool,
 
   /// Build the configuration on a different host over SSH

--- a/crates/nh-darwin/src/darwin.rs
+++ b/crates/nh-darwin/src/darwin.rs
@@ -202,6 +202,7 @@ impl DarwinRebuildArgs {
         .elevate(needs_elevation.then_some(elevation))
         .dry(self.common.dry)
         .show_output(self.show_activation_logs)
+        .pretty(self.show_activation_logs)
         .with_required_env()
         .run()
         .wrap_err("Darwin activation failed")?;

--- a/crates/nh-home/src/args.rs
+++ b/crates/nh-home/src/args.rs
@@ -80,7 +80,15 @@ pub struct HomeRebuildArgs {
   pub backup_extension: Option<String>,
 
   /// Show activation logs
-  #[arg(long, env = "NH_SHOW_ACTIVATION_LOGS", value_parser = clap::builder::BoolishValueParser::new())]
+  #[arg(
+    long,
+    env = "NH_SHOW_ACTIVATION_LOGS",
+    default_value_t = true,
+    action = clap::ArgAction::Set,
+    num_args = 0..=1,
+    default_missing_value = "true",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub show_activation_logs: bool,
 
   /// Build the configuration on a different host over SSH

--- a/crates/nh-home/src/home.rs
+++ b/crates/nh-home/src/home.rs
@@ -238,6 +238,7 @@ impl HomeRebuildArgs {
       .with_required_env()
       .message("Activating configuration")
       .show_output(self.show_activation_logs)
+      .pretty(self.show_activation_logs)
       .run()
       .wrap_err("Activation failed")?;
 

--- a/crates/nh-nixos/src/args.rs
+++ b/crates/nh-nixos/src/args.rs
@@ -181,7 +181,15 @@ pub struct OsRebuildActivateArgs {
   pub rebuild: OsRebuildArgs,
 
   /// Show activation logs
-  #[arg(long, env = "NH_SHOW_ACTIVATION_LOGS", value_parser = clap::builder::BoolishValueParser::new())]
+  #[arg(
+    long,
+    env = "NH_SHOW_ACTIVATION_LOGS",
+    default_value_t = true,
+    action = clap::ArgAction::Set,
+    num_args = 0..=1,
+    default_missing_value = "true",
+    value_parser = clap::builder::BoolishValueParser::new()
+  )]
   pub show_activation_logs: bool,
 }
 

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -384,6 +384,7 @@ impl OsRebuildActivateArgs {
           .preserve_envs(["NIXOS_INSTALL_BOOTLOADER", "NIXOS_NO_CHECK"])
           .with_required_env()
           .show_output(self.show_activation_logs)
+          .pretty(self.show_activation_logs)
           .run()
           .wrap_err("Activation (test) failed")?;
       }


### PR DESCRIPTION
This Pull Request introduces beautifully formatted and summarized activation logs for `nh darwin switch`, `nh home switch`, and `nh os switch`. 

It ports the log parsing and UI formatting logic to dynamically summarize noisy `darwin-rebuild` and `home-manager` logs into clean, concise blocks, greatly improving the UX of platform switches. This formatting is enabled by default via the `--show-activation-logs` flag.

Specific additions:
- Added `format.rs` and `ui.rs` to parse build logs and handle `yansi` colors/spinners.
- Modified `command.rs` to capture `stdout` and redirect it to the parser when the `pretty` flag is passed.
- Fixed some pedantic clippy lints within the formatting logic.
- Updated documentation and defaults across command modules.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
