### PR TITLE
Replace deprecated stdenv.isDarwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,7 @@ mkShell {
     deno
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
   ];
 


### PR DESCRIPTION

This PR replaces the deprecated `stdenv.isDarwin` attribute with `stdenv.hostPlatform.isDarwin` in `shell.nix`.

<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
