### PR TITLE
nh-remote: single-quote `^*` wildcard for non-POSIX remote shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ functionality, under the "Removed" section.
   `/tmp`). nh now resolves the base store path before activation runs, while the
   result symlink is still visible, instead of canonicalizing it afterwards
   ([#659](https://github.com/nix-community/nh/issues/659)).
+- Remote builds via `--build-host` no longer fail when the remote login shell is
+  non-POSIX (e.g. xonsh). The `<drv>^*` extended-output selector was quoted as
+  `prefix'^*'`, which such shells pass through literally (and backslash escaping
+  fares no better, as `\*` is forwarded verbatim and rejected by Nix as an
+  invalid outputs specifier). nh now single-quotes the whole selector
+  (`'<drv>^*'`), which survives both POSIX and non-POSIX shells.
 
 ## 4.4.2
 

--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -680,7 +680,19 @@ fn get_default_ssh_opts() -> Vec<String> {
 }
 
 /// Shell-quote a string for safe passing through SSH to remote shell.
+///
+/// The remote login shell may not be POSIX (e.g. xonsh). shlex quotes only the
+/// unsafe run of a string, so nix's extended-output selector comes out as
+/// `prefix'^*'`. POSIX shells concatenate that back to `prefix^*`, but xonsh
+/// keeps the quotes literal, and backslash-escaping fares no better there:
+/// xonsh forwards `\*` verbatim, which nix rejects as an invalid outputs
+/// specifier. A single quote spanning the whole token survives both, so quote
+/// the selector that way rather than deferring to shlex.
 fn shell_quote(s: &str) -> String {
+  if s.ends_with("^*") && !s.contains('\'') {
+    return format!("'{s}'");
+  }
+
   // Use shlex::try_quote for battle-tested quoting
   // Returns Cow::Borrowed if no quoting needed, Cow::Owned if quoted
   shlex::try_quote(s).map_or_else(
@@ -2479,9 +2491,12 @@ mod tests {
 
   #[test]
   fn test_shell_quote_nix_drv_output() {
-    // Test the drv^* syntax used by nix
+    // The extended-output wildcard must be single-quoted, not
+    // backslash-escaped: xonsh keeps a literal `\*`, which nix rejects.
     let drv_path = "/nix/store/abc123.drv^*";
     let quoted = shell_quote(drv_path);
+    assert_eq!(quoted, "'/nix/store/abc123.drv^*'");
+    assert!(!quoted.contains('\\'));
     let parsed = shlex::split(&quoted).expect("should parse");
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0], drv_path);


### PR DESCRIPTION
Nicer handling of shell quoting for remote commands, particularly non-POSIX shells like xonsh. I don't know why anyone in their right minds would use one of those, but we'll fix it nevertheless. I've changed the shell_quote function to always single-quote extended-output selectors (e.g., strings ending in `^*`) to avoid issues with literal backslashes or quotes being interpreted incorrectly by remote shells.

Change-Id: I4540901787be70a4ca6e13d1f10e67906a6a6964
